### PR TITLE
docs: lead README with the product + hero badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,27 @@
+<div align="center">
+
 # Zenith
 
-> 📖 中文版请看 **[README.zh-CN.md](./README.zh-CN.md)**
+### Bodhi AI — the local-first desktop agent that does the work, not just chats.
 
-> **In one line: the single entry point that ties a "get-things-done" AI desktop product together with the entire system behind it.**
+**It uses tools, keeps memory, and shows you every step — not just a final answer.**
+Zenith is its home base: the desktop product, UI, Rust runtime, Go backend, and docs
+in one recursive clone, released in lockstep.
 
-Bodhi AI turns AI from a chat box into a desktop workbench that actually does the work: you hand it a task, it uses tools, keeps memory, and produces results — and you can watch the whole thing happen, not just read a final answer. Zenith is the home base that holds the desktop product, the UI, the execution engine, the backend, and the docs together — and keeps their releases in sync.
+[![Submodule Guard](https://img.shields.io/github/actions/workflow/status/bigduu/Zenith/submodule-guard.yml?branch=main&label=submodule%20guard&logo=github)](https://github.com/bigduu/Zenith/actions/workflows/submodule-guard.yml)
+[![Release Train](https://img.shields.io/badge/release%20train-Bamboo%20→%20Lotus%20→%20Bodhi-1f6feb)](https://github.com/bigduu/Zenith/actions/workflows/release-train.yml)
+[![Versioning](https://img.shields.io/badge/versioning-nightly%20YYYY.M.N-8a2be2)](https://github.com/bigduu/Zenith/actions/workflows/nightly-release.yml)
+[![中文 README](https://img.shields.io/badge/lang-中文-red)](./README.zh-CN.md)
 
-First time here? Start with **[Bodhi AI](https://github.com/bigduu/Bodhi-AI)**.
+**[▶ Start with Bodhi AI](https://github.com/bigduu/Bodhi-AI)** · [Lotus](https://github.com/bigduu/Lotus) · [Bamboo](https://github.com/bigduu/Bamboo-agent) · [Bodhi Server](https://github.com/bigduu/bodhi-server) · [Pavilion](https://github.com/bigduu/Pavilion) · [Architecture Overview](https://github.com/bigduu/Pavilion/blob/main/articles/zenith-architecture-overview.md)
 
-[Bodhi AI](https://github.com/bigduu/Bodhi-AI) · [Lotus](https://github.com/bigduu/Lotus) · [Bamboo](https://github.com/bigduu/Bamboo-agent) · [Bodhi Server](https://github.com/bigduu/bodhi-server) · [Pavilion](https://github.com/bigduu/Pavilion) · [Architecture Overview](https://github.com/bigduu/Pavilion/blob/main/articles/zenith-architecture-overview.md)
+</div>
+
+<!-- TODO(readme): a product demo GIF/screenshot of Bodhi AI right here is the single biggest
+     click/star driver (cf. aider's screencast). Borrow one from Pavilion/Bodhi when ready:
+     <p align="center"><img src="./docs/assets/bodhi-demo.gif" alt="Bodhi AI in action" width="100%"></p> -->
+
+> Bodhi AI turns AI from a chat box into a desktop workbench that actually does the work: you hand it a task, it uses tools, keeps memory, and produces results — and you can watch the whole thing happen. **Zenith** ties the product, the UI, the execution engine, the backend, and the docs together — and keeps their releases in sync.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,14 +1,27 @@
+<div align="center">
+
 # Zenith
 
-> 📖 For English, see **[README.md](./README.md)**
+### Bodhi AI —— 本地优先的桌面 agent，真正动手干活，而不只是聊天。
 
-> **一句话：把一个能真正帮你把事情做完的 AI 桌面产品，连同它背后的整套系统，组织在同一个仓库里。**
+**它会用工具、有记忆、每一步都看得见 —— 给你的不只是一个最终答案。**
+Zenith 是它的大本营：桌面产品、UI、Rust 运行时、Go 后端与文档，
+一次 `--recursive` clone 全到位，并同步发布。
 
-Bodhi AI 想把 AI 从一个只会聊天的窗口，变成一个真正能推进工作的桌面工作台：你交代任务，它使用工具、留下记忆、把结果做出来，整个过程你都看得见。Zenith 就是这套系统的总入口——它把桌面产品、界面、执行引擎、服务端和官网文档组织在一起，并统一它们的发布节奏。
+[![Submodule Guard](https://img.shields.io/github/actions/workflow/status/bigduu/Zenith/submodule-guard.yml?branch=main&label=submodule%20guard&logo=github)](https://github.com/bigduu/Zenith/actions/workflows/submodule-guard.yml)
+[![Release Train](https://img.shields.io/badge/release%20train-Bamboo%20→%20Lotus%20→%20Bodhi-1f6feb)](https://github.com/bigduu/Zenith/actions/workflows/release-train.yml)
+[![Versioning](https://img.shields.io/badge/versioning-nightly%20YYYY.M.N-8a2be2)](https://github.com/bigduu/Zenith/actions/workflows/nightly-release.yml)
+[![English README](https://img.shields.io/badge/lang-English-blue)](./README.md)
 
-**第一次来？先打开 [Bodhi AI](https://github.com/bigduu/Bodhi-AI)。**
+**[▶ 先看 Bodhi AI](https://github.com/bigduu/Bodhi-AI)** · [Lotus](https://github.com/bigduu/Lotus) · [Bamboo](https://github.com/bigduu/Bamboo-agent) · [Bodhi Server](https://github.com/bigduu/bodhi-server) · [Pavilion](https://github.com/bigduu/Pavilion) · [架构总览](https://github.com/bigduu/Pavilion/blob/main/articles/zenith-architecture-overview.md)
 
-[Bodhi AI](https://github.com/bigduu/Bodhi-AI) · [Lotus](https://github.com/bigduu/Lotus) · [Bamboo](https://github.com/bigduu/Bamboo-agent) · [Bodhi Server](https://github.com/bigduu/bodhi-server) · [Pavilion](https://github.com/bigduu/Pavilion) · [架构总览](https://github.com/bigduu/Pavilion/blob/main/articles/zenith-architecture-overview.md)
+</div>
+
+<!-- TODO(readme): 这里放一张 Bodhi AI 的产品演示 GIF/截图，是最大的点击/star 驱动（参考 aider 的录屏）。
+     素材就绪后从 Pavilion/Bodhi 借用：
+     <p align="center"><img src="./docs/assets/bodhi-demo.gif" alt="Bodhi AI 实际运行" width="100%"></p> -->
+
+> Bodhi AI 想把 AI 从一个只会聊天的窗口，变成一个真正能推进工作的桌面工作台：你交代任务，它使用工具、留下记忆、把结果做出来，整个过程你都看得见。**Zenith** 把产品、界面、执行引擎、服务端和文档组织在一起，并统一它们的发布节奏。
 
 ---
 


### PR DESCRIPTION
## What & why

Benchmarked our README/description against 25+ popular AI-agent repos (goose, aider, jan, letta, anything-llm…). The winners lead with a **product-benefit tagline + a badge row**; Zenith's opening led with "Umbrella monorepo / submodule pointers + release train" — internal plumbing that buries the product and loses anyone searching "AI agent".

## Changes (EN + zh-CN)

- **Product-first hero** — "Bodhi AI — the local-first desktop agent that does the work, not just chats." Zenith is then framed as its home base.
- **Badge row** — submodule-guard CI (live), release-train, nightly-versioning, language switcher
- Language link promoted to a badge-style switcher
- Commented placeholder marking where a Bodhi AI demo GIF should go (per the benchmark, the single biggest click/star driver)

The architecture diagram, module table, release-train section, and quick-start are all unchanged.

## Related

Companion PR on the Bamboo submodule: bigduu/Bamboo-agent#297

## Suggested follow-ups (not in this PR)

- Add a real Bodhi AI demo GIF/screenshot to the hero (asset needed).
- Update the GitHub **About** descriptions for both repos (set via `gh repo edit`; can't be done in a PR) — proposed rewrites are in the session notes.

https://claude.ai/code/session_01XueZpfifCm7cFBkeQJtb5q