### PR TITLE
feat(release): dependency-ordered partial trains + version collision safety

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -38,11 +38,13 @@ jobs:
 
       - name: Calculate next version
         id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
           CURRENT="$(jq -r '.versions.release' "${CONFIG_FILE}")"
-          echo "Current version: ${CURRENT}"
+          echo "Current version (Zenith config): ${CURRENT}"
 
           # Parse current version: YYYY.M.N
           IFS='.' read -r OLD_YEAR OLD_MONTH OLD_N <<< "${CURRENT}"
@@ -51,14 +53,40 @@ jobs:
           YEAR="$(date -u +%Y)"
           MONTH="$(date -u +%-m)"
 
+          MAX_N=0
           if [ "${YEAR}" = "${OLD_YEAR}" ] && [ "${MONTH}" = "${OLD_MONTH}" ]; then
-            # Same year.month → increment N
-            NEW_N=$((OLD_N + 1))
-          else
-            # New year or new month → reset to 1
-            NEW_N=1
+            MAX_N="${OLD_N}"
           fi
 
+          # Ad-hoc or partial releases can publish versions the config never
+          # recorded (and a failed write-back leaves it behind), so also scan
+          # what the registries actually hold for this year.month and advance
+          # past the highest. A registry query failure only logs — the config
+          # floor still applies, and the release train's collision pre-flight
+          # refuses to reuse an occupied version loudly rather than silently.
+          USER_AGENT="zenith-nightly-release/1.0 (+https://github.com/${{ github.repository }})"
+          PATTERN="^${YEAR}\.${MONTH}\.[0-9]+$"
+
+          REMOTE_VERSIONS="$(
+            {
+              curl -sS -H "User-Agent: ${USER_AGENT}" "https://crates.io/api/v1/crates/bamboo-agent" \
+                | jq -r '.versions[].num' || true
+              curl -sS -H "User-Agent: ${USER_AGENT}" "https://registry.npmjs.org/@bigduu%2flotus" \
+                | jq -r '.versions | keys[]' || true
+              gh release list -R bigduu/Bodhi-AI --limit 100 --json tagName \
+                --jq '.[].tagName | sub("^app-v"; "")' || true
+            } 2>/dev/null | { grep -E "${PATTERN}" || true; } | sort -u
+          )"
+
+          for version in ${REMOTE_VERSIONS}; do
+            n="${version##*.}"
+            if [ "${n}" -gt "${MAX_N}" ]; then
+              echo "Registry already has ${version}; advancing the counter past it"
+              MAX_N="${n}"
+            fi
+          done
+
+          NEW_N=$((MAX_N + 1))
           NEW_VERSION="${YEAR}.${MONTH}.${NEW_N}"
           echo "New version: ${NEW_VERSION}"
           echo "new_version=${NEW_VERSION}" >> "${GITHUB_OUTPUT}"
@@ -121,7 +149,7 @@ jobs:
           NEW_VERSION="${{ needs.auto-version.outputs.new_version }}"
 
           echo "Dispatching release-train with version ${NEW_VERSION}"
-          echo "Release order: Bamboo → Lotus → Bodhi"
+          echo "Release order: Lotus → Bamboo → Bodhi"
 
           # The release-train.yml workflow reads from config.json by default
           # (all inputs default to "from_manifest"), so we just need to trigger it.

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -1,8 +1,22 @@
 name: Release Train
 
+# Orchestrates publishing across the three repos in dependency order:
+#
+#   Lotus (npm @bigduu/lotus)  ->  Bamboo (crates.io + embeds that Lotus)  ->  Bodhi (app release consuming both)
+#
+# Gating is event-driven, not time-based: each leg waits for the upstream
+# workflow to finish AND for the artifact to be visible on its registry before
+# the next leg dispatches. The `targets` input releases a subset (a "partial
+# train"), with excluded targets pinned to the last published versions recorded
+# in .github/release-train.config.json.
+
 on:
   workflow_dispatch:
     inputs:
+      targets:
+        description: "Comma-separated subset of lotus,bamboo,bodhi to release (dependency order is fixed: Lotus -> Bamboo -> Bodhi)"
+        required: false
+        default: "lotus,bamboo,bodhi"
       bamboo_ref:
         description: "Ref for Bamboo release workflow (use 'from_manifest' to read Zenith config)"
         required: false
@@ -16,15 +30,15 @@ on:
         required: false
         default: "from_manifest"
       release_version:
-        description: "Unified version for Bamboo + Lotus + Bodhi publish (use 'from_manifest' to read .versions.release)"
+        description: "Unified version for the included targets (use 'from_manifest' to read .versions.release)"
         required: false
         default: "from_manifest"
       bamboo_version:
-        description: "bamboo-agent crate version used by Bodhi release (use 'from_manifest' to read Zenith config)"
+        description: "bamboo-agent crate version (use 'from_manifest' to read Zenith config; excluded targets pin to the last recorded published version)"
         required: false
         default: "from_manifest"
       lotus_version:
-        description: "Lotus npm version used by Bodhi release (use 'from_manifest' to read Zenith config)"
+        description: "Lotus npm version (use 'from_manifest' to read Zenith config; excluded targets pin to the last recorded published version)"
         required: false
         default: "from_manifest"
       bodhi_version:
@@ -35,6 +49,10 @@ on:
         description: "Pass true to skip Lotus publish workflow tests (use 'from_manifest' to read Zenith config)"
         required: false
         default: "from_manifest"
+      resume:
+        description: "Pass true to resume a partially completed train at the same versions: already-published targets are skipped instead of failing the collision pre-flight"
+        required: false
+        default: "false"
 
 permissions:
   contents: read
@@ -42,6 +60,13 @@ permissions:
 jobs:
   orchestrate:
     runs-on: ubuntu-latest
+    outputs:
+      include_lotus: ${{ steps.resolve.outputs.include_lotus }}
+      include_bamboo: ${{ steps.resolve.outputs.include_bamboo }}
+      include_bodhi: ${{ steps.resolve.outputs.include_bodhi }}
+      lotus_version: ${{ steps.resolve.outputs.lotus_version }}
+      bamboo_version: ${{ steps.resolve.outputs.bamboo_version }}
+      bodhi_version: ${{ steps.resolve.outputs.bodhi_version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -78,6 +103,46 @@ jobs:
             printf '%s' "${resolved}"
           }
 
+          TARGETS_INPUT="${{ github.event.inputs.targets }}"
+          if [ -z "${TARGETS_INPUT}" ]; then
+            TARGETS_INPUT="lotus,bamboo,bodhi"
+          fi
+
+          INCLUDE_LOTUS=false
+          INCLUDE_BAMBOO=false
+          INCLUDE_BODHI=false
+          IFS=',' read -ra TARGET_LIST <<< "${TARGETS_INPUT}"
+          for target in "${TARGET_LIST[@]}"; do
+            target="$(printf '%s' "${target}" | tr -d '[:space:]')"
+            case "${target}" in
+              lotus) INCLUDE_LOTUS=true ;;
+              bamboo) INCLUDE_BAMBOO=true ;;
+              bodhi) INCLUDE_BODHI=true ;;
+              "") ;;
+              *)
+                echo "Unknown release target '${target}' (expected a comma-separated subset of: lotus, bamboo, bodhi)"
+                exit 1
+                ;;
+            esac
+          done
+
+          if [ "${INCLUDE_LOTUS}" = "false" ] && [ "${INCLUDE_BAMBOO}" = "false" ] && [ "${INCLUDE_BODHI}" = "false" ]; then
+            echo "targets='${TARGETS_INPUT}' selected nothing to release"
+            exit 1
+          fi
+
+          RESUME="$(printf '%s' "${{ github.event.inputs.resume }}" | tr '[:upper:]' '[:lower:]')"
+          if [ -z "${RESUME}" ]; then
+            RESUME=false
+          fi
+          case "${RESUME}" in
+            true|false) ;;
+            *)
+              echo "resume must be true or false, got: ${RESUME}"
+              exit 1
+              ;;
+          esac
+
           BAMBOO_REF="$(resolve_value "${{ github.event.inputs.bamboo_ref }}" '.refs.bamboo')"
           LOTUS_REF="$(resolve_value "${{ github.event.inputs.lotus_ref }}" '.refs.lotus')"
           BODHI_REF="$(resolve_value "${{ github.event.inputs.bodhi_ref }}" '.refs.bodhi')"
@@ -89,32 +154,31 @@ jobs:
             RELEASE_VERSION="${RELEASE_VERSION_INPUT}"
           fi
 
-          BAMBOO_VERSION_INPUT="${{ github.event.inputs.bamboo_version }}"
-          if [ -n "${BAMBOO_VERSION_INPUT}" ] && [ "${BAMBOO_VERSION_INPUT}" != "from_manifest" ]; then
-            BAMBOO_VERSION="${BAMBOO_VERSION_INPUT}"
-          elif [ -n "${RELEASE_VERSION}" ] && [ "${RELEASE_VERSION}" != "null" ]; then
-            BAMBOO_VERSION="${RELEASE_VERSION}"
-          else
-            BAMBOO_VERSION="$(resolve_value "${BAMBOO_VERSION_INPUT}" '.versions.bamboo')"
-          fi
+          # Included targets publish at the unified release version; excluded
+          # targets pin to the last recorded published version so partial
+          # trains consume real artifacts instead of the new (unpublished)
+          # release number. An explicit per-repo input always wins.
+          resolve_component_version() {
+            local input_value="$1"
+            local included="$2"
+            local jq_path="$3"
 
-          LOTUS_VERSION_INPUT="${{ github.event.inputs.lotus_version }}"
-          if [ -n "${LOTUS_VERSION_INPUT}" ] && [ "${LOTUS_VERSION_INPUT}" != "from_manifest" ]; then
-            LOTUS_VERSION="${LOTUS_VERSION_INPUT}"
-          elif [ -n "${RELEASE_VERSION}" ] && [ "${RELEASE_VERSION}" != "null" ]; then
-            LOTUS_VERSION="${RELEASE_VERSION}"
-          else
-            LOTUS_VERSION="$(resolve_value "${LOTUS_VERSION_INPUT}" '.versions.lotus')"
-          fi
+            if [ -n "${input_value}" ] && [ "${input_value}" != "from_manifest" ]; then
+              printf '%s' "${input_value}"
+              return
+            fi
 
-          BODHI_VERSION_INPUT="${{ github.event.inputs.bodhi_version }}"
-          if [ -n "${BODHI_VERSION_INPUT}" ] && [ "${BODHI_VERSION_INPUT}" != "from_manifest" ]; then
-            BODHI_VERSION="${BODHI_VERSION_INPUT}"
-          elif [ -n "${RELEASE_VERSION}" ] && [ "${RELEASE_VERSION}" != "null" ]; then
-            BODHI_VERSION="${RELEASE_VERSION}"
-          else
-            BODHI_VERSION="$(resolve_value "${BODHI_VERSION_INPUT}" '.versions.bodhi')"
-          fi
+            if [ "${included}" = "true" ] && [ -n "${RELEASE_VERSION}" ] && [ "${RELEASE_VERSION}" != "null" ]; then
+              printf '%s' "${RELEASE_VERSION}"
+              return
+            fi
+
+            resolve_value "" "${jq_path}"
+          }
+
+          BAMBOO_VERSION="$(resolve_component_version "${{ github.event.inputs.bamboo_version }}" "${INCLUDE_BAMBOO}" '.versions.bamboo')"
+          LOTUS_VERSION="$(resolve_component_version "${{ github.event.inputs.lotus_version }}" "${INCLUDE_LOTUS}" '.versions.lotus')"
+          BODHI_VERSION="$(resolve_component_version "${{ github.event.inputs.bodhi_version }}" "${INCLUDE_BODHI}" '.versions.bodhi')"
 
           LOTUS_SKIP_TESTS="$(resolve_value "${{ github.event.inputs.lotus_skip_tests }}" '.options.lotus_skip_tests')"
 
@@ -127,6 +191,10 @@ jobs:
           esac
 
           {
+            echo "include_lotus=${INCLUDE_LOTUS}"
+            echo "include_bamboo=${INCLUDE_BAMBOO}"
+            echo "include_bodhi=${INCLUDE_BODHI}"
+            echo "resume=${RESUME}"
             echo "bamboo_ref=${BAMBOO_REF}"
             echo "lotus_ref=${LOTUS_REF}"
             echo "bodhi_ref=${BODHI_REF}"
@@ -139,6 +207,7 @@ jobs:
 
           cat <<EOF
           Resolved release inputs:
+          - targets: lotus=${INCLUDE_LOTUS} bamboo=${INCLUDE_BAMBOO} bodhi=${INCLUDE_BODHI} (resume=${RESUME})
           - bamboo_ref=${BAMBOO_REF}
           - lotus_ref=${LOTUS_REF}
           - bodhi_ref=${BODHI_REF}
@@ -162,9 +231,118 @@ jobs:
             exit 1
           fi
 
-      - name: Run Bamboo -> Lotus -> Bodhi
+      - name: Pre-flight version checks
+        id: preflight
         env:
           GH_TOKEN: ${{ secrets.RELEASE_ORCHESTRATOR_TOKEN }}
+          INCLUDE_LOTUS: ${{ steps.resolve.outputs.include_lotus }}
+          INCLUDE_BAMBOO: ${{ steps.resolve.outputs.include_bamboo }}
+          INCLUDE_BODHI: ${{ steps.resolve.outputs.include_bodhi }}
+          RESUME: ${{ steps.resolve.outputs.resume }}
+          LOTUS_VERSION: ${{ steps.resolve.outputs.lotus_version }}
+          BAMBOO_VERSION: ${{ steps.resolve.outputs.bamboo_version }}
+          BODHI_VERSION: ${{ steps.resolve.outputs.bodhi_version }}
+        run: |
+          set -euo pipefail
+
+          USER_AGENT="zenith-release-train/1.0 (+https://github.com/${{ github.repository }})"
+
+          crates_version_exists() {
+            local status
+            status="$(curl -sS -o /dev/null -w "%{http_code}" \
+              -H "User-Agent: ${USER_AGENT}" \
+              "https://crates.io/api/v1/crates/bamboo-agent/$1" || true)"
+            [ "${status}" = "200" ]
+          }
+
+          npm_version_exists() {
+            local status
+            status="$(curl -sS -o /dev/null -w "%{http_code}" \
+              -H "User-Agent: ${USER_AGENT}" \
+              "https://registry.npmjs.org/@bigduu%2flotus/$1" || true)"
+            [ "${status}" = "200" ]
+          }
+
+          bodhi_release_exists() {
+            gh release view "app-v$1" -R bigduu/Bodhi-AI >/dev/null 2>&1
+          }
+
+          SKIP_LOTUS=false
+          SKIP_BAMBOO=false
+          SKIP_BODHI=false
+
+          # Included targets must not collide with an already-published
+          # version. Both downstream publish workflows treat "already exists"
+          # as success (for retries), so without this check a collision would
+          # silently keep the stale artifact and report a green train.
+          check_collision() {
+            local name="$1" version="$2" exists_fn="$3" skip_var="$4"
+            if [ "${version}" = "latest" ]; then
+              return 0
+            fi
+            if "${exists_fn}" "${version}"; then
+              if [ "${RESUME}" = "true" ]; then
+                echo "${name}@${version} already published; resume=true -> skipping this leg."
+                eval "${skip_var}=true"
+              else
+                echo "::error::${name}@${version} is already published. An ad-hoc release may have consumed this number; pick an unused version, or pass resume=true to resume a partial train at these exact versions."
+                exit 1
+              fi
+            fi
+          }
+
+          if [ "${INCLUDE_LOTUS}" = "true" ]; then
+            check_collision "@bigduu/lotus" "${LOTUS_VERSION}" npm_version_exists SKIP_LOTUS
+          fi
+          if [ "${INCLUDE_BAMBOO}" = "true" ]; then
+            check_collision "bamboo-agent" "${BAMBOO_VERSION}" crates_version_exists SKIP_BAMBOO
+          fi
+          if [ "${INCLUDE_BODHI}" = "true" ]; then
+            check_collision "Bodhi app release" "${BODHI_VERSION}" bodhi_release_exists SKIP_BODHI
+          fi
+
+          # Versions consumed from excluded targets must actually exist —
+          # a partial train must never point a release at a phantom artifact.
+          require_exists() {
+            local desc="$1" version="$2" exists_fn="$3"
+            if [ "${version}" = "latest" ]; then
+              return 0
+            fi
+            if ! "${exists_fn}" "${version}"; then
+              echo "::error::${desc}@${version} is not published, but an included target depends on it and its producer is not in targets. Release it first or fix the version."
+              exit 1
+            fi
+          }
+
+          if [ "${INCLUDE_BAMBOO}" = "true" ] && [ "${INCLUDE_LOTUS}" != "true" ]; then
+            require_exists "@bigduu/lotus" "${LOTUS_VERSION}" npm_version_exists
+          fi
+          if [ "${INCLUDE_BODHI}" = "true" ]; then
+            if [ "${INCLUDE_LOTUS}" != "true" ]; then
+              require_exists "@bigduu/lotus" "${LOTUS_VERSION}" npm_version_exists
+            fi
+            if [ "${INCLUDE_BAMBOO}" != "true" ]; then
+              require_exists "bamboo-agent" "${BAMBOO_VERSION}" crates_version_exists
+            fi
+          fi
+
+          {
+            echo "skip_lotus=${SKIP_LOTUS}"
+            echo "skip_bamboo=${SKIP_BAMBOO}"
+            echo "skip_bodhi=${SKIP_BODHI}"
+          } >> "${GITHUB_OUTPUT}"
+
+          echo "Pre-flight passed (skip: lotus=${SKIP_LOTUS} bamboo=${SKIP_BAMBOO} bodhi=${SKIP_BODHI})"
+
+      - name: Run Lotus -> Bamboo -> Bodhi
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_ORCHESTRATOR_TOKEN }}
+          INCLUDE_LOTUS: ${{ steps.resolve.outputs.include_lotus }}
+          INCLUDE_BAMBOO: ${{ steps.resolve.outputs.include_bamboo }}
+          INCLUDE_BODHI: ${{ steps.resolve.outputs.include_bodhi }}
+          SKIP_LOTUS: ${{ steps.preflight.outputs.skip_lotus }}
+          SKIP_BAMBOO: ${{ steps.preflight.outputs.skip_bamboo }}
+          SKIP_BODHI: ${{ steps.preflight.outputs.skip_bodhi }}
           BAMBOO_REF: ${{ steps.resolve.outputs.bamboo_ref }}
           LOTUS_REF: ${{ steps.resolve.outputs.lotus_ref }}
           BODHI_REF: ${{ steps.resolve.outputs.bodhi_ref }}
@@ -284,12 +462,118 @@ jobs:
             exit 1
           }
 
-          dispatch_and_wait "bigduu/Bamboo-agent" "publish-crate.yml" "${BAMBOO_REF}" "version=${BAMBOO_VERSION}"
-          wait_for_crates_version "bamboo-agent" "${BAMBOO_VERSION}"
+          # Lotus goes first so Bamboo can embed the exact same-day frontend
+          # (publish-crate.yml installs @bigduu/lotus@<lotus_version> from npm).
+          if [ "${INCLUDE_LOTUS}" = "true" ]; then
+            if [ "${SKIP_LOTUS}" = "true" ]; then
+              echo "Skipping Lotus leg (resume: @bigduu/lotus@${LOTUS_VERSION} is already on npm)."
+            else
+              dispatch_and_wait "bigduu/Lotus" "publish-npm.yml" "${LOTUS_REF}" "version=${LOTUS_VERSION}" "skip_tests=${LOTUS_SKIP_TESTS}"
+              wait_for_npm_version "@bigduu%2flotus" "${LOTUS_VERSION}"
+            fi
+          fi
 
-          dispatch_and_wait "bigduu/Lotus" "publish-npm.yml" "${LOTUS_REF}" "version=${LOTUS_VERSION}" "skip_tests=${LOTUS_SKIP_TESTS}"
-          wait_for_npm_version "@bigduu%2flotus" "${LOTUS_VERSION}"
+          if [ "${INCLUDE_BAMBOO}" = "true" ]; then
+            if [ "${SKIP_BAMBOO}" = "true" ]; then
+              echo "Skipping Bamboo leg (resume: bamboo-agent@${BAMBOO_VERSION} is already on crates.io)."
+            else
+              dispatch_and_wait "bigduu/Bamboo-agent" "publish-crate.yml" "${BAMBOO_REF}" "version=${BAMBOO_VERSION}" "lotus_version=${LOTUS_VERSION}"
+              wait_for_crates_version "bamboo-agent" "${BAMBOO_VERSION}"
+            fi
+          fi
 
-          dispatch_and_wait "bigduu/Bodhi-AI" "release.yml" "${BODHI_REF}" "bodhi_version=${BODHI_VERSION}" "bamboo_version=${BAMBOO_VERSION}" "lotus_version=${LOTUS_VERSION}"
+          if [ "${INCLUDE_BODHI}" = "true" ]; then
+            if [ "${SKIP_BODHI}" = "true" ]; then
+              echo "Skipping Bodhi leg (resume: release app-v${BODHI_VERSION} already exists)."
+            else
+              dispatch_and_wait "bigduu/Bodhi-AI" "release.yml" "${BODHI_REF}" "bodhi_version=${BODHI_VERSION}" "bamboo_version=${BAMBOO_VERSION}" "lotus_version=${LOTUS_VERSION}"
+            fi
+          fi
 
           echo "Release train completed successfully."
+
+  record:
+    name: Record published versions
+    needs: orchestrate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - name: Write published versions back to Zenith config
+        env:
+          INCLUDE_LOTUS: ${{ needs.orchestrate.outputs.include_lotus }}
+          INCLUDE_BAMBOO: ${{ needs.orchestrate.outputs.include_bamboo }}
+          INCLUDE_BODHI: ${{ needs.orchestrate.outputs.include_bodhi }}
+          LOTUS_VERSION: ${{ needs.orchestrate.outputs.lotus_version }}
+          BAMBOO_VERSION: ${{ needs.orchestrate.outputs.bamboo_version }}
+          BODHI_VERSION: ${{ needs.orchestrate.outputs.bodhi_version }}
+        run: |
+          set -euo pipefail
+          CONFIG_FILE=".github/release-train.config.json"
+
+          # Ad-hoc and partial trains would otherwise leave the config behind
+          # reality: the next nightly would recompute an already-consumed
+          # version and the collision pre-flight would stop it. Recording what
+          # was actually published keeps the counter monotonic.
+          jq \
+            --arg lotus "${LOTUS_VERSION}" \
+            --arg bamboo "${BAMBOO_VERSION}" \
+            --arg bodhi "${BODHI_VERSION}" \
+            --argjson inc_lotus "${INCLUDE_LOTUS}" \
+            --argjson inc_bamboo "${INCLUDE_BAMBOO}" \
+            --argjson inc_bodhi "${INCLUDE_BODHI}" \
+            '(if $inc_lotus and $lotus != "latest" then .versions.lotus = $lotus else . end)
+             | (if $inc_bamboo and $bamboo != "latest" then .versions.bamboo = $bamboo else . end)
+             | (if $inc_bodhi and $bodhi != "latest" then .versions.bodhi = $bodhi else . end)' \
+            "${CONFIG_FILE}" > "${CONFIG_FILE}.tmp"
+          mv "${CONFIG_FILE}.tmp" "${CONFIG_FILE}"
+
+          # Advance the unified release counter past every version this train
+          # published so the nightly bump never reuses one of them.
+          CANDIDATES="$(jq -r '.versions.release' "${CONFIG_FILE}")"
+          for entry in "${INCLUDE_LOTUS}:${LOTUS_VERSION}" "${INCLUDE_BAMBOO}:${BAMBOO_VERSION}" "${INCLUDE_BODHI}:${BODHI_VERSION}"; do
+            included="${entry%%:*}"
+            version="${entry#*:}"
+            if [ "${included}" = "true" ] && [ "${version}" != "latest" ]; then
+              CANDIDATES="${CANDIDATES}
+          ${version}"
+            fi
+          done
+          NEW_RELEASE="$(printf '%s\n' "${CANDIDATES}" | tr -d ' ' | sort -V | tail -1)"
+          jq --arg release "${NEW_RELEASE}" '.versions.release = $release' "${CONFIG_FILE}" > "${CONFIG_FILE}.tmp"
+          mv "${CONFIG_FILE}.tmp" "${CONFIG_FILE}"
+
+          echo "Updated ${CONFIG_FILE}:"
+          cat "${CONFIG_FILE}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add "${CONFIG_FILE}"
+          if git diff --cached --quiet; then
+            echo "Config already records these versions; nothing to write back."
+            exit 0
+          fi
+
+          git commit -m "chore: record published versions (release train run ${{ github.run_id }})"
+
+          # main receives concurrent automation commits (nightly bump, pointer
+          # bumps) — rebase and retry instead of failing on the first reject.
+          for attempt in 1 2 3 4 5; do
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            echo "Push rejected (attempt ${attempt}/5); rebasing onto latest main and retrying..."
+            git pull --rebase origin main
+            sleep 5
+          done
+
+          echo "Failed to push the version write-back after 5 attempts."
+          exit 1

--- a/.github/workflows/submodule-guard.yml
+++ b/.github/workflows/submodule-guard.yml
@@ -50,7 +50,8 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const core = require("@actions/core");
+            // `core` is injected by github-script; redeclaring it is a
+            // SyntaxError that failed this check on every PR.
             const { owner, repo } = context.repo;
             const pull_number = context.payload.pull_request.number;
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Zenith is its home base: the desktop product, UI, Rust runtime, Go backend, and 
 in one recursive clone, released in lockstep.
 
 [![Submodule Guard](https://img.shields.io/github/actions/workflow/status/bigduu/Zenith/submodule-guard.yml?branch=main&label=submodule%20guard&logo=github)](https://github.com/bigduu/Zenith/actions/workflows/submodule-guard.yml)
-[![Release Train](https://img.shields.io/badge/release%20train-Bamboo%20→%20Lotus%20→%20Bodhi-1f6feb)](https://github.com/bigduu/Zenith/actions/workflows/release-train.yml)
+[![Release Train](https://img.shields.io/badge/release%20train-Lotus%20→%20Bamboo%20→%20Bodhi-1f6feb)](https://github.com/bigduu/Zenith/actions/workflows/release-train.yml)
 [![Versioning](https://img.shields.io/badge/versioning-nightly%20YYYY.M.N-8a2be2)](https://github.com/bigduu/Zenith/actions/workflows/nightly-release.yml)
 [![中文 README](https://img.shields.io/badge/lang-中文-red)](./README.zh-CN.md)
 
@@ -31,7 +31,7 @@ in one recursive clone, released in lockstep.
 |---|---|
 | **A map of the whole system** | One repo shows how product, UI, runtime, backend, and docs divide the work and fit together |
 | **Five submodules, one clone** | Pull the full stack in a single recursive clone |
-| **Coordinated release train** | Bamboo → Lotus → Bodhi published in order, all driven by one config file |
+| **Coordinated release train** | Lotus → Bamboo → Bodhi published in dependency order, all driven by one config file |
 | **Daily nightly versioning** | Calendar-versioned (`YYYY.M.N`) auto-bump and nightly release |
 | **Submodule guard** | CI validates submodule pointers on every push and PR |
 | **Clear "start here" routing** | Whether you want the product, the frontend, or the runtime, there is a clear door in |
@@ -105,13 +105,15 @@ The five-way split exists so each layer can evolve on its own yet converge into 
 
 Shipping several repos at once, in dependency order, is error-prone. Zenith reduces it to one config plus one workflow.
 
-The order is fixed:
+The order is fixed by the dependency graph:
 
-1. **Bamboo** → publish crate (`publish-crate.yml` in `bigduu/Bamboo-agent`)
-2. **Lotus** → publish npm package `@bigduu/lotus` (`publish-npm.yml` in `bigduu/Lotus`)
-3. **Bodhi** → build & ship desktop assets (`deploy.yml` in `bigduu/Bodhi-AI`)
+1. **Lotus** → publish npm package `@bigduu/lotus` (`publish-npm.yml` in `bigduu/Lotus`)
+2. **Bamboo** → publish crates, embedding that exact Lotus as the web frontend (`publish-crate.yml` in `bigduu/Bamboo-agent`)
+3. **Bodhi** → build & ship desktop assets consuming both (`release.yml` in `bigduu/Bodhi-AI`)
 
 Between steps, the train **waits until the artifact is actually visible on crates.io / npm** before continuing (see `wait_for_crates_version` / `wait_for_npm_version` in `release-train.yml`). All versions and refs default to `.github/release-train.config.json` (`from_manifest`), and can be overridden when dispatched manually.
+
+The train also supports **partial releases**: dispatch with `targets` (e.g. `bamboo,bodhi`) to release a subset — excluded repos are pinned to the last published versions recorded in the config, and a pre-flight check refuses to reuse an already-published version (pass `resume=true` to resume a partially completed train instead). After a successful run, the train writes the published versions back to the config, and the nightly bump additionally scans the registries for the month's highest published number — so the counter never collides with an ad-hoc release.
 
 Current config (`.github/release-train.config.json`):
 
@@ -127,7 +129,7 @@ Related workflows (under `.github/workflows/`):
 
 | Workflow | Purpose |
 |---|---|
-| `release-train.yml` | Manual coordinated release: Bamboo → Lotus → Bodhi |
+| `release-train.yml` | Coordinated release (full or partial via `targets`): Lotus → Bamboo → Bodhi |
 | `nightly-release.yml` | Daily nightly auto-bump (`YYYY.M.N`) at 04:00 UTC |
 | `submodule-guard.yml` | Validates submodule pointers on push & PR |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@ Zenith 是它的大本营：桌面产品、UI、Rust 运行时、Go 后端与文
 一次 `--recursive` clone 全到位，并同步发布。
 
 [![Submodule Guard](https://img.shields.io/github/actions/workflow/status/bigduu/Zenith/submodule-guard.yml?branch=main&label=submodule%20guard&logo=github)](https://github.com/bigduu/Zenith/actions/workflows/submodule-guard.yml)
-[![Release Train](https://img.shields.io/badge/release%20train-Bamboo%20→%20Lotus%20→%20Bodhi-1f6feb)](https://github.com/bigduu/Zenith/actions/workflows/release-train.yml)
+[![Release Train](https://img.shields.io/badge/release%20train-Lotus%20→%20Bamboo%20→%20Bodhi-1f6feb)](https://github.com/bigduu/Zenith/actions/workflows/release-train.yml)
 [![Versioning](https://img.shields.io/badge/versioning-nightly%20YYYY.M.N-8a2be2)](https://github.com/bigduu/Zenith/actions/workflows/nightly-release.yml)
 [![English README](https://img.shields.io/badge/lang-English-blue)](./README.md)
 
@@ -31,7 +31,7 @@ Zenith 是它的大本营：桌面产品、UI、Rust 运行时、Go 后端与文
 |---|---|
 | **整套系统的地图** | 一个仓库就能看清产品、UI、runtime、backend、文档如何分工与协作 |
 | **5 个 submodule 一键拉取** | `--recursive` 一次拉全栈，不用手动跑五个仓库 |
-| **协调发布列车** | Bamboo → Lotus → Bodhi 顺序发布，版本号从一份配置统一驱动 |
+| **协调发布列车** | Lotus → Bamboo → Bodhi 按依赖顺序发布，版本号从一份配置统一驱动 |
 | **每日 Nightly 自动版本** | 按 `YYYY.M.N` 日历版本自动递增并触发发布 |
 | **指针守护** | CI 在每次 push / PR 校验 submodule 指针的健康 |
 | **明确的“从哪开始”** | 无论你想看产品、写前端还是改 runtime，都有明确入口 |
@@ -105,13 +105,15 @@ Zenith 最大的价值，是让任何一个人都能快速找到正确的入口�
 
 多个仓库要同时升级版本、按依赖顺序发布，很容易出错。Zenith 用一份配置 + 一条 workflow 把它变成一次点击。
 
-发布顺序固定为：
+发布顺序由依赖关系固定为：
 
-1. **Bamboo** → 发布 crate（`bigduu/Bamboo-agent` 的 `publish-crate.yml`）
-2. **Lotus** → 发布 npm 包 `@bigduu/lotus`（`bigduu/Lotus` 的 `publish-npm.yml`）
-3. **Bodhi** → 构建并发布桌面产物（`bigduu/Bodhi-AI` 的 `deploy.yml`）
+1. **Lotus** → 发布 npm 包 `@bigduu/lotus`（`bigduu/Lotus` 的 `publish-npm.yml`）
+2. **Bamboo** → 发布 crate，并把当天这个 Lotus 嵌入为 web 前端（`bigduu/Bamboo-agent` 的 `publish-crate.yml`）
+3. **Bodhi** → 构建并发布桌面产物，消费前两者（`bigduu/Bodhi-AI` 的 `release.yml`）
 
 每一步之间，release train 会**等待制品在 crates.io / npm 上真正可见**后再进入下一步（见 `release-train.yml` 中的 `wait_for_crates_version` / `wait_for_npm_version`）。所有版本与 ref 默认从 `.github/release-train.config.json` 读取（`from_manifest`），也可在手动触发时覆盖。
+
+列车也支持**部分发车**：手动触发时传 `targets`（如 `bamboo,bodhi`）只发布子集——未选中的仓库固定使用配置中记录的最近已发布版本；预检会拒绝复用已发布过的版本号（重跑半途失败的列车请传 `resume=true`）。列车成功后会把实际发布的版本写回配置，nightly 定版时还会扫描 registry 取当月最大序号，保证计数器不会与临时发布撞号。
 
 当前配置 (`.github/release-train.config.json`):
 
@@ -127,7 +129,7 @@ Zenith 最大的价值，是让任何一个人都能快速找到正确的入口�
 
 | Workflow | 作用 |
 |---|---|
-| `release-train.yml` | 手动触发的协调发布：Bamboo → Lotus → Bodhi |
+| `release-train.yml` | 协调发布（全量或用 `targets` 部分发车）：Lotus → Bamboo → Bodhi |
 | `nightly-release.yml` | 每天 UTC 04:00（北京时间 12:00）按 `YYYY.M.N` 自动递增版本并触发 |
 | `submodule-guard.yml` | 每次 push / PR 校验 submodule 指针 |
 


### PR DESCRIPTION
Implements the release-freedom plan agreed in session (independent per-repo releases with a global control point):

## 1. Train order: Lotus → Bamboo → Bodhi

Bamboo's publish now receives `lotus_version` and embeds the exact same-day `@bigduu/lotus` from npm instead of the committed stale zip. **Merge bigduu/Bamboo-agent#432 first** — it adds the `lotus_version` input to `publish-crate.yml`; dispatching with an unknown input fails.

## 2. Version collision safety

- **Pre-flight**: included targets must NOT already exist on their registry (crates.io / npm / Bodhi GH release). Both downstream publish workflows treat "already exists" as success (retry idempotency), so a collision previously shipped nothing and reported a green train. `resume=true` turns collisions into leg-skips for resuming a partially completed train.
- **Write-back**: a new `record` job commits the actually-published versions back to `release-train.config.json` (rebase-retry push, coexists with nightly auto-commits).
- **Registry-aware nightly**: the nightly version calc scans crates.io + npm + Bodhi releases for the month's highest `YYYY.M.N` and advances past it, so ad-hoc releases can never make the counter collide.

## 3. Partial trains (`targets`)

Dispatch with `targets: bamboo,bodhi` (any subset) to release only those, in the same dependency order. Excluded repos pin to the last recorded published versions from the config, with an existence pre-flight so a partial train can never reference a phantom artifact. Typical flows:
- Bamboo bugfix → `targets: bamboo,bodhi` ships a new backend+app against the existing Lotus in ~40 min.
- Frontend-only fix → `targets: lotus,bamboo,bodhi` (full, since Bamboo embeds Lotus).

## Verification

All new bash logic was extracted and exercised locally against the real registries:
- nightly calc: fresh config → `2026.7.9`; stale config (`2026.7.3`) → registries pull it to `2026.7.9`
- pre-flight: collision at published `2026.7.8` fails / `resume=true` skips all legs / phantom dependency (`bamboo@2026.7.50`) fails / partial with published pin passes
- resolve: full & partial target sets, whitespace tolerance, unknown-target rejection, explicit per-repo override precedence
- record: partial write-back, `sort -V` numeric ordering (`.10` > `.9`), no-op when config already current

READMEs (en/zh) updated to the new order + partial-train docs (also fixes the stale `deploy.yml` reference — Bodhi's workflow is `release.yml`).

https://claude.ai/code/session_0138j11hELj87StgjdjRQE3Z