### PR TITLE
docs: align agent review label

### DIFF
--- a/.github/labels.tsv
+++ b/.github/labels.tsv
@@ -19,7 +19,7 @@ agent:blocked	#bfd4f2	Blocked by dependency or conflict
 
 # --- Review Labels ---
 review:needed	#fbca04	Waiting for review
-review:agent	#5319e7	Agent review done, waiting for human
+review:agent	#5319e7	Agent review complete; merge gates may proceed
 review:changes	#e11d48	Changes requested
 
 # --- Scope Labels ---


### PR DESCRIPTION
## Summary

- align the canonical `review:agent` label description with the autonomous merge policy added in #20
- remove the remaining implication that every agent-reviewed PR must wait for a human

## Test Plan

- `git diff --check`
- verify the TSV entry remains tab-delimited

## Screenshots

N/A
