### PR TITLE
[zenith] chore: add Jiandu as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "magpie"]
 	path = magpie
 	url = git@github.com:bigduu/Magpie.git
+[submodule "jiandu"]
+	path = jiandu
+	url = https://github.com/bigduu/Jiandu.git


### PR DESCRIPTION
## Summary

- register `jiandu/` as a Zenith Git submodule using the public HTTPS Jiandu repository
- pin the gitlink to the verified Jiandu `main` commit `91abccb2227acef81349b10b02fba199af759cd3`
- keep the root change limited to `.gitmodules` and the new mode `160000` gitlink

Jiandu is the standalone filesystem-memory MCP service extracted for use by Bamboo and other agents.

## Testing

- `git diff --check origin/main...HEAD`
- local reproduction of `Validate Submodule Pointers` for the changed `jiandu` path
- fresh shallow clone followed by `git submodule update --init --depth 1 -- jiandu`
- verified gitlink mode `160000`, expected SHA, checkout SHA, and clean submodule status

## Screenshots

Not applicable; this is repository metadata only.

## Submodule Updates

- `jiandu`: absent -> `91abccb2227acef81349b10b02fba199af759cd3` (add the verified standalone filesystem-memory MCP service through its public HTTPS repository)

Closes #114