### PR TITLE
docs: teach agents to use Jiandu shared memory (#142)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,9 +48,12 @@ other agents should use the same store only through Jiandu MCP.
 - Treat memory as supporting evidence: an empty query does not prove a fact is
   false, and recalled memory must be checked against current files and tools.
   Correct an evident argument or context error, but do not loop or claim recall or
-  persistence unless the MCP call succeeds. If Jiandu is unavailable, continue
-  from current evidence, disclose the gap when it materially affects the answer,
-  and do not write a fallback memory file into the repository.
+  persistence unless the MCP call succeeds. A mutation error or interrupted
+  response has an unknown outcome: run `inspect` first, run `rebuild` if only
+  derived artifacts are stale, then verify with `query` or `get`; never blindly
+  retry. If Jiandu is unavailable, continue from current evidence, disclose the
+  gap when it materially affects the answer, and do not write a fallback memory
+  file into the repository.
 
 ## Build, Test, and Development Commands
 From repository root:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,16 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-Zenith is a thin monorepo wrapper around five Git submodules:
+Zenith is a thin monorepo wrapper around nine Git submodules:
 - `bamboo/`: Rust AI-agent backend framework (`src/`, `tests/`, `docs/`).
 - `lotus/`: React + Vite web app (`src/`, `e2e/`, `public/`).
 - `bodhi/`: Tauri desktop shell (`src-tauri/`) that coordinates with `lotus`.
 - `pavilion/`: React + Vite official website and docs (`src/`, `public/`).
 - `bodhi-server/`: Go backend API server (`api/`, `internal/`, `cmd/`).
+- `nova/`: Rust computer-use MCP server for native desktop interaction.
+- `lotus-next/`: responsive next-generation React + Vite frontend.
+- `magpie/`: standalone IM connector and Bamboo service plugin.
+- `jiandu/`: agent-independent, filesystem-backed shared-memory MCP service.
 
 Root files (`README.md`, `.gitmodules`) manage submodule pointers; most feature work happens inside submodules.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,11 +53,13 @@ other agents should use the same store only through Jiandu MCP.
   false, and recalled memory must be checked against current files and tools.
   Correct an evident argument or context error, but do not loop or claim recall or
   persistence unless the MCP call succeeds. A mutation error or interrupted
-  response has an unknown outcome: run `inspect` first, run `rebuild` if only
-  derived artifacts are stale, then verify with `query` or `get`; never blindly
-  retry. If Jiandu is unavailable, continue from current evidence, disclose the
-  gap when it materially affects the answer, and do not write a fallback memory
-  file into the repository.
+  response has an unknown outcome. For a Session mutation, verify the same topic
+  with `session_read` (and use `session_list_topics` only when the topic itself is
+  uncertain). For a durable Project/Global mutation, run `inspect` for that scope,
+  run `rebuild` only if derived artifacts are stale, then verify with `query` or
+  `get`. Never blindly retry. If Jiandu is unavailable, continue from current
+  evidence, disclose the gap when it materially affects the answer, and do not
+  write a fallback memory file into the repository.
 
 ## Build, Test, and Development Commands
 From repository root:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,43 @@ Key architecture docs (in `bamboo/docs/`):
 - `remote-mailbox-broker-design.md` — the standalone message broker + `ask_agent`/`deploy_agent` design (SHIPPED status).
 - `remote-actor-plan.md` — remote-actor seams (P0/P1/P2): launcher / discovery / placement abstractions.
 
+## Shared Memory via Jiandu MCP
+
+Use the Jiandu server's single `memory` tool; an MCP host may expose it under a
+namespace such as `mcp__jiandu__memory`. Select behavior with its `action`.
+Never edit Jiandu data files directly or create repository files as a memory
+fallback. Bamboo may optimize recalled memory while assembling agent context;
+other agents should use the same store only through Jiandu MCP.
+
+- Recall before guessing: use `query` when prior user preferences, confirmed
+  decisions, or project history may affect the task. Use `get` for an ID returned
+  by `query` when the exact or full item is needed. Use `session_read` for current
+  host-session or workstream continuity, such as after resuming or compaction;
+  session memory is not cross-session durable recall.
+- Record at the right layer: use `session_append` for temporary progress,
+  blockers, hypotheses, and next steps. Keep the note concise and use
+  `session_replace` when it needs compression. Use `write` only for a confirmed,
+  durable, non-derivable fact that will help future sessions. Query first, then
+  store one atomic fact with a specific, searchable title. Never store secrets,
+  credentials, or tokens.
+- Respect scope and authority: Project/global durable memory is the cross-agent
+  surface for agents connected to the same Jiandu data store; session memory is
+  tied to the host `session_id`. Use Project scope for project-specific decisions
+  and references, and Global only for truly cross-project preferences or stable
+  references. Project access comes only from the MCP host context. Normally omit
+  `project_key`; if supplied, it may only match the host Project. Never invent or
+  copy a `project_key`, and never move a Project fact to Global because Project
+  access is unavailable.
+- Keep scratch out of durable memory: do not persist logs, tentative conclusions,
+  derivable code facts, current file or runtime state, or routine task completion
+  with `write`.
+- Treat memory as supporting evidence: an empty query does not prove a fact is
+  false, and recalled memory must be checked against current files and tools.
+  Correct an evident argument or context error, but do not loop or claim recall or
+  persistence unless the MCP call succeeds. If Jiandu is unavailable, continue
+  from current evidence, disclose the gap when it materially affects the answer,
+  and do not write a fallback memory file into the repository.
+
 ## Build, Test, and Development Commands
 From repository root:
 - `git submodule update --init --recursive` - initialize all module checkouts.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 ### Bodhi AI — the local-first desktop agent that does the work, not just chats.
 
 **It uses tools, keeps memory, and shows you every step — not just a final answer.**
-Zenith is its home base: the desktop product, UI, Rust runtime, Go backend, and docs
-in one recursive clone, released in lockstep.
+Zenith is its home base: the desktop product, UIs, Rust runtime, Go backend, shared
+memory, computer use, IM integration, and docs in one recursive clone.
 
 [![Submodule Guard](https://img.shields.io/github/actions/workflow/status/bigduu/Zenith/submodule-guard.yml?branch=main&label=submodule%20guard&logo=github)](https://github.com/bigduu/Zenith/actions/workflows/submodule-guard.yml)
 [![Release Train](https://img.shields.io/badge/release%20train-Lotus%20→%20Bamboo%20→%20Bodhi-1f6feb)](https://github.com/bigduu/Zenith/actions/workflows/release-train.yml)
@@ -30,7 +30,7 @@ in one recursive clone, released in lockstep.
 | Capability | What it means |
 |---|---|
 | **A map of the whole system** | One repo shows how product, UI, runtime, backend, and docs divide the work and fit together |
-| **Five submodules, one clone** | Pull the full stack in a single recursive clone |
+| **Nine submodules, one clone** | Pull the full product stack and companion services in a single recursive clone |
 | **Coordinated release train** | Lotus → Bamboo → Bodhi published in dependency order, all driven by one config file |
 | **Daily nightly versioning** | Calendar-versioned (`YYYY.M.N`) auto-bump and nightly release |
 | **Submodule guard** | CI validates submodule pointers on every push and PR |
@@ -40,7 +40,7 @@ in one recursive clone, released in lockstep.
 
 ## Architecture
 
-Zenith holds almost no business logic itself. It is a thin-shell monorepo: it pins five Git submodules, owns the root-level documentation, and orchestrates releases across repos. The real features live inside the submodules.
+Zenith holds almost no business logic itself. It is a thin-shell monorepo: it pins nine Git submodules, owns the root-level documentation, and orchestrates releases across repos. The real features live inside the submodules.
 
 ```mermaid
 graph TD
@@ -51,6 +51,10 @@ graph TD
   Z --> R["Bamboo<br/>local-first Rust agent runtime"]
   Z --> S["Bodhi Server<br/>Go backend"]
   Z --> P["Pavilion<br/>website & docs"]
+  Z --> J["Jiandu<br/>shared-memory MCP service"]
+  Z --> N["Nova<br/>computer-use MCP server"]
+  Z --> LN["Lotus Next<br/>responsive frontend rebuild"]
+  Z --> M["Magpie<br/>IM connector for Bamboo"]
 
   B -. embeds .-> L
   L -. HTTP / SSE .-> R
@@ -69,6 +73,10 @@ graph TD
 | **Bamboo** | `bamboo/` | Execution engine: local-first Rust agent runtime — tasks, tools, memory, HTTP/SSE API | [Bamboo Agent](https://github.com/bigduu/Bamboo-agent) |
 | **Bodhi Server** | `bodhi-server/` | Backend: Go server — auth, persistence, quota/billing, LLM proxy | [Bodhi Server](https://github.com/bigduu/bodhi-server) |
 | **Pavilion** | `pavilion/` | Website & docs: download page, doc center, public narrative | [Pavilion](https://github.com/bigduu/Pavilion) |
+| **Jiandu** | `jiandu/` | Shared memory: agent-independent filesystem-backed MCP service | [Jiandu](https://github.com/bigduu/Jiandu) · [agent guidance](./AGENTS.md#shared-memory-via-jiandu-mcp) |
+| **Nova** | `nova/` | Computer use: native desktop interaction exposed through MCP | [Nova](https://github.com/bigduu/Nova) |
+| **Lotus Next** | `lotus-next/` | Next UI track: responsive React + Vite frontend developed alongside Lotus | [Lotus Next](https://github.com/bigduu/lotus-next) |
+| **Magpie** | `magpie/` | IM integration: standalone connector and Bamboo service plugin | [Magpie](https://github.com/bigduu/Magpie) |
 | **Zenith (root)** | `.` | Coordinator: submodule pointers, root docs, release train | You are here |
 
 ---
@@ -93,13 +101,17 @@ Zenith's biggest job is getting any person to the right door fast.
 
 ### The stack, organized on purpose
 
-The five-way split exists so each layer can evolve on its own yet converge into one product at release time:
+The core product path is split so each layer can evolve on its own yet converge into one product at release time:
 
 - **UI & experience** live in Lotus (React/Vite) and iterate and test independently.
 - **Execution** lives in Bamboo (Rust), local-first, runnable as a standalone HTTP service.
 - **Account, quota, billing, LLM proxy** live in Bodhi Server (Go) — the server-trusted concerns, visible as real modules under `bodhi-server/internal/` (`auth`, `quota`, `pricing`, `proxy`, `database`).
 - **The desktop shell** lives in Bodhi and only wraps the UI into an installable desktop app.
 - **Public narrative** lives in Pavilion, decoupled from code.
+
+Four companion submodules keep separate boundaries: Jiandu provides shared memory
+over MCP, Nova provides computer use over MCP, Lotus Next is the responsive UI
+successor track, and Magpie connects IM platforms to Bamboo.
 
 ### Coordinated release train
 
@@ -189,7 +201,7 @@ git submodule status
 git submodule update --remote --recursive
 
 # after submodule work, bump pointers from root
-git add .gitmodules bamboo bodhi lotus pavilion bodhi-server
+git add .gitmodules bamboo bodhi bodhi-server jiandu lotus lotus-next magpie nova pavilion
 git commit -m "chore: bump submodule pointers"
 git push
 ```
@@ -207,6 +219,10 @@ git push
 | Bamboo — Rust agent runtime | https://github.com/bigduu/Bamboo-agent |
 | Bodhi Server — Go backend | https://github.com/bigduu/bodhi-server |
 | Pavilion — website & docs | https://github.com/bigduu/Pavilion |
+| Jiandu — shared-memory MCP service | https://github.com/bigduu/Jiandu |
+| Nova — computer-use MCP server | https://github.com/bigduu/Nova |
+| Lotus Next — responsive frontend successor track | https://github.com/bigduu/lotus-next |
+| Magpie — IM connector for Bamboo | https://github.com/bigduu/Magpie |
 
 **Key docs**
 - [Zenith Architecture Overview](https://github.com/bigduu/Pavilion/blob/main/articles/zenith-architecture-overview.md) — why the system is organized this way

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,8 +5,8 @@
 ### Bodhi AI —— 本地优先的桌面 agent，真正动手干活，而不只是聊天。
 
 **它会用工具、有记忆、每一步都看得见 —— 给你的不只是一个最终答案。**
-Zenith 是它的大本营：桌面产品、UI、Rust 运行时、Go 后端与文档，
-一次 `--recursive` clone 全到位，并同步发布。
+Zenith 是它的大本营：桌面产品、前端、Rust 运行时、Go 后端、共享记忆、
+电脑操作、IM 集成与文档，一次 `--recursive` clone 全到位。
 
 [![Submodule Guard](https://img.shields.io/github/actions/workflow/status/bigduu/Zenith/submodule-guard.yml?branch=main&label=submodule%20guard&logo=github)](https://github.com/bigduu/Zenith/actions/workflows/submodule-guard.yml)
 [![Release Train](https://img.shields.io/badge/release%20train-Lotus%20→%20Bamboo%20→%20Bodhi-1f6feb)](https://github.com/bigduu/Zenith/actions/workflows/release-train.yml)
@@ -30,7 +30,7 @@ Zenith 是它的大本营：桌面产品、UI、Rust 运行时、Go 后端与文
 | 能力 | 说明 |
 |---|---|
 | **整套系统的地图** | 一个仓库就能看清产品、UI、runtime、backend、文档如何分工与协作 |
-| **5 个 submodule 一键拉取** | `--recursive` 一次拉全栈，不用手动跑五个仓库 |
+| **9 个 submodule 一键拉取** | `--recursive` 一次拉取产品栈与配套服务 |
 | **协调发布列车** | Lotus → Bamboo → Bodhi 按依赖顺序发布，版本号从一份配置统一驱动 |
 | **每日 Nightly 自动版本** | 按 `YYYY.M.N` 日历版本自动递增并触发发布 |
 | **指针守护** | CI 在每次 push / PR 校验 submodule 指针的健康 |
@@ -40,7 +40,7 @@ Zenith 是它的大本营：桌面产品、UI、Rust 运行时、Go 后端与文
 
 ## 架构地图
 
-Zenith 本身几乎不放业务代码，它是一个“薄壳”monorepo：维护 5 个 Git submodule 的指针、根级说明文档，以及跨仓库的发布编排。真正的功能都活在子模块里。
+Zenith 本身几乎不放业务代码，它是一个“薄壳”monorepo：维护 9 个 Git submodule 的指针、根级说明文档，以及跨仓库的发布编排。真正的功能都活在子模块里。
 
 ```mermaid
 graph TD
@@ -51,6 +51,10 @@ graph TD
   Z --> R["Bamboo<br/>local-first Rust agent runtime"]
   Z --> S["Bodhi Server<br/>Go backend"]
   Z --> P["Pavilion<br/>website & docs"]
+  Z --> J["Jiandu<br/>shared-memory MCP service"]
+  Z --> N["Nova<br/>computer-use MCP server"]
+  Z --> LN["Lotus Next<br/>responsive frontend rebuild"]
+  Z --> M["Magpie<br/>IM connector for Bamboo"]
 
   B -. embeds .-> L
   L -. HTTP / SSE .-> R
@@ -69,6 +73,10 @@ graph TD
 | **Bamboo** | `bamboo/` | 执行引擎：本地优先的 Rust agent runtime，任务、工具、记忆与 HTTP/SSE API | [Bamboo Agent](https://github.com/bigduu/Bamboo-agent) |
 | **Bodhi Server** | `bodhi-server/` | 服务端能力：Go 后端，认证、持久化、配额/计费与 LLM 代理 | [Bodhi Server](https://github.com/bigduu/bodhi-server) |
 | **Pavilion** | `pavilion/` | 官网与文档：下载入口、文档中心与对外叙事 | [Pavilion](https://github.com/bigduu/Pavilion) |
+| **Jiandu** | `jiandu/` | 共享记忆：agent 无关、文件系统持久化的 MCP 服务 | [Jiandu](https://github.com/bigduu/Jiandu) · [agent 使用指南](./AGENTS.md#shared-memory-via-jiandu-mcp) |
+| **Nova** | `nova/` | 电脑操作：通过 MCP 暴露原生桌面交互能力 | [Nova](https://github.com/bigduu/Nova) |
+| **Lotus Next** | `lotus-next/` | 下一代界面：与 Lotus 并行开发的响应式 React + Vite 前端 | [Lotus Next](https://github.com/bigduu/lotus-next) |
+| **Magpie** | `magpie/` | IM 集成：独立连接器与 Bamboo service plugin | [Magpie](https://github.com/bigduu/Magpie) |
 | **Zenith (root)** | `.` | 协调仓库：submodule 指针、根级文档、release train | 你在这里 |
 
 ---
@@ -93,13 +101,17 @@ Zenith 最大的价值，是让任何一个人都能快速找到正确的入口�
 
 ### 2. 这套栈为什么这样分
 
-拆成五块不是为了好看，而是为了让每一层都能独立演进，又能在发布时收敛成一个产品：
+核心产品链路按层拆分，让每一层都能独立演进，又能在发布时收敛成一个产品：
 
 - **界面与体验** 放在 Lotus（React/Vite），可以独立迭代、独立测试。
 - **执行逻辑** 放在 Bamboo（Rust），本地优先、可单独跑成 HTTP 服务。
 - **账号、配额、计费、LLM 代理** 放在 Bodhi Server（Go），把需要服务端信任的能力集中起来。`bodhi-server/internal/` 下能看到 `auth`、`quota`、`pricing`、`proxy`、`database` 等真实模块。
 - **桌面壳** 放在 Bodhi，只负责“把界面装进一个可安装的桌面 App”。
 - **对外叙事** 放在 Pavilion，与代码解耦。
+
+另外四个 submodule 保持独立边界：Jiandu 通过 MCP 提供共享记忆，Nova
+通过 MCP 提供电脑操作，Lotus Next 是响应式前端的后继路线，Magpie
+负责把 IM 平台连接到 Bamboo。
 
 ### 3. 协调发布列车
 
@@ -189,7 +201,7 @@ git submodule status
 git submodule update --remote --recursive
 
 # 子模块改动后，回到根仓库提交指针
-git add .gitmodules bamboo bodhi lotus pavilion bodhi-server
+git add .gitmodules bamboo bodhi bodhi-server jiandu lotus lotus-next magpie nova pavilion
 git commit -m "chore: bump submodule pointers"
 git push
 ```
@@ -207,6 +219,10 @@ git push
 | Bamboo — Rust agent runtime | https://github.com/bigduu/Bamboo-agent |
 | Bodhi Server — Go backend | https://github.com/bigduu/bodhi-server |
 | Pavilion — 官网与文档 | https://github.com/bigduu/Pavilion |
+| Jiandu — 共享记忆 MCP 服务 | https://github.com/bigduu/Jiandu |
+| Nova — 电脑操作 MCP 服务 | https://github.com/bigduu/Nova |
+| Lotus Next — 响应式前端后继路线 | https://github.com/bigduu/lotus-next |
+| Magpie — Bamboo 的 IM 连接器 | https://github.com/bigduu/Magpie |
 
 **关键文档**
 - [Zenith 架构总览](https://github.com/bigduu/Pavilion/blob/main/articles/zenith-architecture-overview.md) — 整套系统为什么这样组织


### PR DESCRIPTION
## Summary

- teach all repository agents to use Jiandu through its single shared-memory MCP tool
- keep Bamboo-specific context optimization in Bamboo and keep other agents MCP-only
- define scope authority, durable versus session memory, evidence checks, and interrupted-mutation recovery
- make Claude inherit the same policy through @AGENTS.md
- correct AGENTS and both READMEs from five to the actual nine submodules

## Test Plan

- verified .gitmodules and the HEAD tree contain exactly nine gitlinks
- verified AGENTS.md, README.md, and README.zh-CN.md list all nine paths
- scanned for stale five-submodule wording
- checked relative Markdown links and the new AGENTS anchor
- ran git diff --check

## Scope

Documentation only. No gitlink, implementation, workflow, or release configuration change.

Closes #142
