### PR TITLE
docs: correct root runtime boundaries (#150)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 ### Bodhi AI — the local-first desktop agent that does the work, not just chats.
 
 **It uses tools, keeps memory, and shows you every step — not just a final answer.**
-Zenith is its home base: the desktop product, UIs, Rust runtime, Go backend, shared
-memory, computer use, IM integration, and docs in one recursive clone.
+Zenith is its home base: the desktop product, UIs, Rust runtime, optional hosted
+services, shared memory, computer use, IM integration, and docs in one recursive clone.
 
 [![Submodule Guard](https://img.shields.io/github/actions/workflow/status/bigduu/Zenith/submodule-guard.yml?branch=main&label=submodule%20guard&logo=github)](https://github.com/bigduu/Zenith/actions/workflows/submodule-guard.yml)
 [![Release Train](https://img.shields.io/badge/release%20train-Lotus%20→%20Bamboo%20→%20Bodhi-1f6feb)](https://github.com/bigduu/Zenith/actions/workflows/release-train.yml)
@@ -17,7 +17,7 @@ memory, computer use, IM integration, and docs in one recursive clone.
 
 </div>
 
-> Bodhi AI turns AI from a chat box into a desktop workbench that actually does the work: you hand it a task, it uses tools, keeps memory, and produces results — and you can watch the whole thing happen. **Zenith** ties the product, the UI, the execution engine, the backend, and the docs together — and keeps their releases in sync.
+> Bodhi AI turns AI from a chat box into a desktop workbench that actually does the work: you hand it a task, it uses tools, keeps memory, and produces results — and you can watch the whole thing happen. **Zenith** ties the product, the UI, the execution engine, optional hosted services, and the docs together — and keeps their releases in sync.
 
 ---
 
@@ -29,7 +29,7 @@ memory, computer use, IM integration, and docs in one recursive clone.
 | **Nine submodules, one clone** | Pull the full product stack and companion services in a single recursive clone |
 | **Coordinated release train** | Lotus → Bamboo → Bodhi published in dependency order, all driven by one config file |
 | **Daily nightly versioning** | Calendar-versioned (`YYYY.M.N`) auto-bump and nightly release |
-| **Submodule guard** | CI validates submodule pointers on every push and PR |
+| **Submodule guard** | CI validates submodule pointers on pushes to and pull requests targeting `main` |
 | **Clear "start here" routing** | Whether you want the product, the frontend, or the runtime, there is a clear door in |
 
 ---
@@ -45,33 +45,35 @@ graph TD
   Z --> B["Bodhi AI<br/>desktop product surface (Tauri shell)"]
   Z --> L["Lotus<br/>React + Vite UI layer"]
   Z --> R["Bamboo<br/>local-first Rust agent runtime"]
-  Z --> S["Bodhi Server<br/>Go backend"]
+  Z --> S["Bodhi Server<br/>optional hosted service"]
   Z --> P["Pavilion<br/>website & docs"]
-  Z --> J["Jiandu<br/>shared-memory MCP service"]
+  Z --> J["Jiandu<br/>Rust memory crate + stdio MCP"]
   Z --> N["Nova<br/>computer-use MCP server"]
-  Z --> LN["Lotus Next<br/>responsive frontend rebuild"]
+  Z --> LN["Lotus Next<br/>experimental frontend track"]
   Z --> M["Magpie<br/>IM connector for Bamboo"]
 
-  B -. embeds .-> L
-  L -. HTTP / SSE .-> R
-  R -. auth · quota · LLM proxy .-> S
+  B -. starts / reuses / health-checks .-> R
+  R -. packaged builds serve embedded frontend .-> L
+  L -->|HTTP APIs + shared /v2/stream WebSocket| R
+  L -. legacy SSE fallback .-> R
+  R -. optional /proxy/* when configured .-> S
   P -. explains .-> B
 ```
 
-> **Note** —— The Bodhi shell hosts the UI and native integration; Lotus is the actual UI; Lotus talks to the Bamboo runtime over **HTTP / SSE** (not Tauri IPC); Bamboo defers account, quota, billing, and LLM-proxy concerns to the Go backend, Bodhi Server.
+> **Note** —— Bodhi owns the native desktop shell and the Bamboo sidecar lifecycle: it starts or reuses `bamboo serve` and waits for it to become healthy. Packaged builds load the Lotus UI served by Bamboo; development keeps Lotus on its Vite dev server while Bamboo runs alongside it. Lotus sends requests over HTTP and receives live events through the shared `/v2/stream` WebSocket by default, with legacy SSE only when WebSocket is disabled or its initial connection cannot be established. Bodhi Server is optional for local operation and is used, when configured, for accounts/authentication, credential storage, quota/billing, model routing, and provider proxying.
 
 ### What each module does
 
 | Module | Path | Role | Start here |
 |---|---|---|---|
-| **Bodhi AI** | `bodhi/` | Product surface: Tauri desktop shell hosting the UI, native integration, packaging | [Bodhi AI](https://github.com/bigduu/Bodhi-AI) |
-| **Lotus** | `lotus/` | UI layer: React + Vite frontend, live event stream, view state, settings | [Lotus](https://github.com/bigduu/Lotus) |
-| **Bamboo** | `bamboo/` | Execution engine: local-first Rust agent runtime — tasks, tools, memory, HTTP/SSE API | [Bamboo Agent](https://github.com/bigduu/Bamboo-agent) |
-| **Bodhi Server** | `bodhi-server/` | Backend: Go server — auth, persistence, quota/billing, LLM proxy | [Bodhi Server](https://github.com/bigduu/bodhi-server) |
+| **Bodhi AI** | `bodhi/` | Product surface: Tauri shell, native integration, packaging, and managed Bamboo sidecar lifecycle | [Bodhi AI](https://github.com/bigduu/Bodhi-AI) |
+| **Lotus** | `lotus/` | UI layer: React + Vite, HTTP requests, shared WebSocket live events, legacy SSE fallback, view state, settings | [Lotus](https://github.com/bigduu/Lotus) |
+| **Bamboo** | `bamboo/` | Execution engine and production Lotus host: local-first Rust runtime with HTTP, WebSocket, and legacy SSE APIs | [Bamboo Agent](https://github.com/bigduu/Bamboo-agent) |
+| **Bodhi Server** | `bodhi-server/` | Optional hosted Go service: accounts/auth, API keys, encrypted provider credentials, model routing, billing/quota, provider proxy | [Bodhi Server](https://github.com/bigduu/bodhi-server) |
 | **Pavilion** | `pavilion/` | Website & docs: download page, doc center, public narrative | [Pavilion](https://github.com/bigduu/Pavilion) |
-| **Jiandu** | `jiandu/` | Shared memory: agent-independent filesystem-backed MCP service | [Jiandu](https://github.com/bigduu/Jiandu) · [agent guidance](./AGENTS.md#shared-memory-via-jiandu-mcp) |
+| **Jiandu** | `jiandu/` | Shared memory: runtime-independent filesystem-backed Rust library plus stdio MCP server with one `memory` tool | [Jiandu](https://github.com/bigduu/Jiandu) · [agent guidance](./AGENTS.md#shared-memory-via-jiandu-mcp) |
 | **Nova** | `nova/` | Computer use: native desktop interaction exposed through MCP | [Nova](https://github.com/bigduu/Nova) |
-| **Lotus Next** | `lotus-next/` | Next UI track: responsive React + Vite frontend developed alongside Lotus | [Lotus Next](https://github.com/bigduu/lotus-next) |
+| **Lotus Next** | `lotus-next/` | Experimental parallel UI track: responsive React + Vite rebuild without current feature-parity or production-readiness claims | [Lotus Next](https://github.com/bigduu/lotus-next) |
 | **Magpie** | `magpie/` | IM integration: standalone connector and Bamboo service plugin | [Magpie](https://github.com/bigduu/Magpie) |
 | **Zenith (root)** | `.` | Coordinator: submodule pointers, root docs, release train | You are here |
 
@@ -92,22 +94,28 @@ Zenith's biggest job is getting any person to the right door fast.
 - Desktop product / Tauri shell → `bodhi/`
 - Frontend interaction / React UI → `lotus/`
 - Agent runtime / Rust backend → `bamboo/`
-- Backend / Go backend → `bodhi-server/`
+- Optional hosted accounts / credentials / routing / billing → `bodhi-server/`
 - Website / docs / public content → `pavilion/`
+- Shared-memory MCP → `jiandu/`
+- Computer-use MCP → `nova/`
+- Experimental next-generation UI → `lotus-next/`
+- IM connector / Bamboo service plugin → `magpie/`
 
 ### The stack, organized on purpose
 
 The core product path is split so each layer can evolve on its own yet converge into one product at release time:
 
-- **UI & experience** live in Lotus (React/Vite) and iterate and test independently.
-- **Execution** lives in Bamboo (Rust), local-first, runnable as a standalone HTTP service.
-- **Account, quota, billing, LLM proxy** live in Bodhi Server (Go) — the server-trusted concerns, visible as real modules under `bodhi-server/internal/` (`auth`, `quota`, `pricing`, `proxy`, `database`).
-- **The desktop shell** lives in Bodhi and only wraps the UI into an installable desktop app.
+- **UI & experience** live in Lotus (React/Vite); requests use HTTP and live events use one shared WebSocket by default, with legacy SSE fallback.
+- **Execution and production UI hosting** live in Bamboo (Rust), local-first and runnable as a standalone service.
+- **Optional hosted accounts, credentials, model routing, quota/billing, and provider proxying** live in Bodhi Server (Go) when configured. The local Bodhi + Bamboo path does not require it.
+- **The desktop shell** lives in Bodhi: it owns native integration, packaging, and the managed Bamboo sidecar lifecycle, while Bamboo serves the embedded Lotus frontend in release builds.
 - **Public narrative** lives in Pavilion, decoupled from code.
 
-Four companion submodules keep separate boundaries: Jiandu provides shared memory
-over MCP, Nova provides computer use over MCP, Lotus Next is the responsive UI
-successor track, and Magpie connects IM platforms to Bamboo.
+Four companion submodules keep separate boundaries: Jiandu is a standalone stdio
+MCP server and Rust library for runtime-independent shared memory; Nova provides
+computer use over MCP; Lotus Next is an experimental frontend track developed
+alongside Lotus and is not the current Bodhi default; Magpie connects IM platforms
+to Bamboo.
 
 ### Coordinated release train
 
@@ -133,7 +141,7 @@ Related workflows (under `.github/workflows/`):
 |---|---|
 | `release-train.yml` | Coordinated release (full or partial via `targets`): Lotus → Bamboo → Bodhi |
 | `nightly-release.yml` | Daily nightly auto-bump (`YYYY.M.N`) at 04:00 UTC |
-| `submodule-guard.yml` | Validates submodule pointers on push & PR |
+| `submodule-guard.yml` | Validates submodule pointers on pushes to and pull requests targeting `main` |
 
 > **Default policy** —— Normal releases go through Zenith's release train; per-repo standalone flows are for recovery or special cases only.
 
@@ -157,12 +165,14 @@ git submodule update --init --recursive
 ### Run the desktop app
 
 ```bash
-cd bodhi
+cd lotus
+npm install
+cd ../bodhi
 npm install
 npm run tauri:dev
 ```
 
-> Bodhi's `web:dev` / `tauri:dev` drive the Vite frontend in `../lotus`; see `bodhi/package.json`.
+> `tauri:dev` builds `../bamboo` as the managed debug sidecar, starts `../lotus` with Vite HMR, and launches Bodhi. Bodhi starts or reuses Bamboo and waits for its health endpoint, while the development UI remains on Vite; packaged builds load the Lotus frontend served by Bamboo. See `bodhi/package.json` and the [Bodhi README](https://github.com/bigduu/Bodhi-AI).
 
 ### Run the UI on its own
 
@@ -171,6 +181,8 @@ cd lotus
 npm install
 npm run dev
 ```
+
+> The Vite UI can start on its own; live agent data requires a separately running Bamboo service.
 
 ### Run the agent runtime
 
@@ -207,11 +219,11 @@ git push
 | Bodhi AI — desktop product surface | https://github.com/bigduu/Bodhi-AI |
 | Lotus — React UI layer | https://github.com/bigduu/Lotus |
 | Bamboo — Rust agent runtime | https://github.com/bigduu/Bamboo-agent |
-| Bodhi Server — Go backend | https://github.com/bigduu/bodhi-server |
+| Bodhi Server — optional hosted accounts, credentials, routing, billing/quota, and provider proxy | https://github.com/bigduu/bodhi-server |
 | Pavilion — website & docs | https://github.com/bigduu/Pavilion |
-| Jiandu — shared-memory MCP service | https://github.com/bigduu/Jiandu |
+| Jiandu — filesystem-backed Rust memory library + stdio MCP server | https://github.com/bigduu/Jiandu |
 | Nova — computer-use MCP server | https://github.com/bigduu/Nova |
-| Lotus Next — responsive frontend successor track | https://github.com/bigduu/lotus-next |
+| Lotus Next — experimental parallel frontend track, not the current Bodhi default | https://github.com/bigduu/lotus-next |
 | Magpie — IM connector for Bamboo | https://github.com/bigduu/Magpie |
 
 **Key docs**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,7 +5,7 @@
 ### Bodhi AI —— 本地优先的桌面 agent，真正动手干活，而不只是聊天。
 
 **它会用工具、有记忆、每一步都看得见 —— 给你的不只是一个最终答案。**
-Zenith 是它的大本营：桌面产品、前端、Rust 运行时、Go 后端、共享记忆、
+Zenith 是它的大本营：桌面产品、前端、Rust 运行时、可选托管服务、共享记忆、
 电脑操作、IM 集成与文档，一次 `--recursive` clone 全到位。
 
 [![Submodule Guard](https://img.shields.io/github/actions/workflow/status/bigduu/Zenith/submodule-guard.yml?branch=main&label=submodule%20guard&logo=github)](https://github.com/bigduu/Zenith/actions/workflows/submodule-guard.yml)
@@ -17,7 +17,7 @@ Zenith 是它的大本营：桌面产品、前端、Rust 运行时、Go 后端�
 
 </div>
 
-> Bodhi AI 想把 AI 从一个只会聊天的窗口，变成一个真正能推进工作的桌面工作台：你交代任务，它使用工具、留下记忆、把结果做出来，整个过程你都看得见。**Zenith** 把产品、界面、执行引擎、服务端和文档组织在一起，并统一它们的发布节奏。
+> Bodhi AI 想把 AI 从一个只会聊天的窗口，变成一个真正能推进工作的桌面工作台：你交代任务，它使用工具、留下记忆、把结果做出来，整个过程你都看得见。**Zenith** 把产品、界面、执行引擎、可选托管服务和文档组织在一起，并统一它们的发布节奏。
 
 ---
 
@@ -29,7 +29,7 @@ Zenith 是它的大本营：桌面产品、前端、Rust 运行时、Go 后端�
 | **9 个 submodule 一键拉取** | `--recursive` 一次拉取产品栈与配套服务 |
 | **协调发布列车** | Lotus → Bamboo → Bodhi 按依赖顺序发布，版本号从一份配置统一驱动 |
 | **每日 Nightly 自动版本** | 按 `YYYY.M.N` 日历版本自动递增并触发发布 |
-| **指针守护** | CI 在每次 push / PR 校验 submodule 指针的健康 |
+| **指针守护** | CI 在 push 到 `main` 及目标为 `main` 的 PR 中校验 submodule 指针 |
 | **明确的“从哪开始”** | 无论你想看产品、写前端还是改 runtime，都有明确入口 |
 
 ---
@@ -45,33 +45,35 @@ graph TD
   Z --> B["Bodhi AI<br/>desktop product surface (Tauri shell)"]
   Z --> L["Lotus<br/>React + Vite UI layer"]
   Z --> R["Bamboo<br/>local-first Rust agent runtime"]
-  Z --> S["Bodhi Server<br/>Go backend"]
+  Z --> S["Bodhi Server<br/>可选托管服务"]
   Z --> P["Pavilion<br/>website & docs"]
-  Z --> J["Jiandu<br/>shared-memory MCP service"]
+  Z --> J["Jiandu<br/>Rust 记忆库 + stdio MCP"]
   Z --> N["Nova<br/>computer-use MCP server"]
-  Z --> LN["Lotus Next<br/>responsive frontend rebuild"]
+  Z --> LN["Lotus Next<br/>实验性前端路线"]
   Z --> M["Magpie<br/>IM connector for Bamboo"]
 
-  B -. embeds .-> L
-  L -. HTTP / SSE .-> R
-  R -. auth · quota · LLM proxy .-> S
+  B -. 启动 / 复用 / 健康检查 .-> R
+  R -. 打包构建提供内嵌前端 .-> L
+  L -->|HTTP API + 共享 /v2/stream WebSocket| R
+  L -. legacy SSE fallback .-> R
+  R -. 配置后可选使用 /proxy/* .-> S
   P -. explains .-> B
 ```
 
-> **重要** —— Bodhi 桌面壳负责承载界面与原生集成；Lotus 是真正的界面层；Lotus 通过 **HTTP / SSE** 与 Bamboo runtime 通信（不是 Tauri IPC）。Bamboo 把需要账号、配额、计费与 LLM 代理的能力交给 Go 后端 Bodhi Server。
+> **重要** —— Bodhi 负责原生桌面壳和 Bamboo sidecar 生命周期：启动或复用 `bamboo serve`，并等待健康检查通过。打包构建加载由 Bamboo 提供的 Lotus 界面；开发模式保持使用 Lotus Vite dev server，同时在旁运行 Bamboo。Lotus 用 HTTP 发请求，实时事件默认走共享 `/v2/stream` WebSocket；只有显式关闭 WebSocket 或首次建连失败时才回退到 legacy SSE。Bodhi Server 对本地运行不是必需依赖；配置使用时，它提供账号/认证、凭据存储、配额/计费、模型路由与 provider proxy。
 
 ### 各模块职责
 
 | 模块 | 路径 | 角色 | 从哪开始 |
 |---|---|---|---|
-| **Bodhi AI** | `bodhi/` | 对外产品门面：Tauri 桌面壳，承载 UI、原生集成与打包发布 | [Bodhi AI](https://github.com/bigduu/Bodhi-AI) |
-| **Lotus** | `lotus/` | UI 交互层：React + Vite 前端，实时事件流、界面状态与设置 | [Lotus](https://github.com/bigduu/Lotus) |
-| **Bamboo** | `bamboo/` | 执行引擎：本地优先的 Rust agent runtime，任务、工具、记忆与 HTTP/SSE API | [Bamboo Agent](https://github.com/bigduu/Bamboo-agent) |
-| **Bodhi Server** | `bodhi-server/` | 服务端能力：Go 后端，认证、持久化、配额/计费与 LLM 代理 | [Bodhi Server](https://github.com/bigduu/bodhi-server) |
+| **Bodhi AI** | `bodhi/` | 对外产品门面：Tauri 桌面壳、原生集成、打包发布与受管 Bamboo sidecar 生命周期 | [Bodhi AI](https://github.com/bigduu/Bodhi-AI) |
+| **Lotus** | `lotus/` | UI 交互层：React + Vite、HTTP 请求、共享 WebSocket 实时事件、legacy SSE fallback、界面状态与设置 | [Lotus](https://github.com/bigduu/Lotus) |
+| **Bamboo** | `bamboo/` | 执行引擎与生产 Lotus host：本地优先 Rust runtime，提供 HTTP、WebSocket 与 legacy SSE API | [Bamboo Agent](https://github.com/bigduu/Bamboo-agent) |
+| **Bodhi Server** | `bodhi-server/` | 可选托管 Go 服务：账号/认证、API key、加密 provider 凭据、模型路由、配额/计费与 provider proxy | [Bodhi Server](https://github.com/bigduu/bodhi-server) |
 | **Pavilion** | `pavilion/` | 官网与文档：下载入口、文档中心与对外叙事 | [Pavilion](https://github.com/bigduu/Pavilion) |
-| **Jiandu** | `jiandu/` | 共享记忆：agent 无关、文件系统持久化的 MCP 服务 | [Jiandu](https://github.com/bigduu/Jiandu) · [agent 使用指南](./AGENTS.md#shared-memory-via-jiandu-mcp) |
+| **Jiandu** | `jiandu/` | 共享记忆：runtime 无关、文件系统持久化的 Rust 库与 stdio MCP server，只暴露一个 `memory` tool | [Jiandu](https://github.com/bigduu/Jiandu) · [agent 使用指南](./AGENTS.md#shared-memory-via-jiandu-mcp) |
 | **Nova** | `nova/` | 电脑操作：通过 MCP 暴露原生桌面交互能力 | [Nova](https://github.com/bigduu/Nova) |
-| **Lotus Next** | `lotus-next/` | 下一代界面：与 Lotus 并行开发的响应式 React + Vite 前端 | [Lotus Next](https://github.com/bigduu/lotus-next) |
+| **Lotus Next** | `lotus-next/` | 实验性并行界面：响应式 React + Vite 重构，当前不声明功能等价或生产就绪 | [Lotus Next](https://github.com/bigduu/lotus-next) |
 | **Magpie** | `magpie/` | IM 集成：独立连接器与 Bamboo service plugin | [Magpie](https://github.com/bigduu/Magpie) |
 | **Zenith (root)** | `.` | 协调仓库：submodule 指针、根级文档、release train | 你在这里 |
 
@@ -92,22 +94,27 @@ Zenith 最大的价值，是让任何一个人都能快速找到正确的入口�
 - 桌面产品 / Tauri 壳 → `bodhi/`
 - 前端交互 / React UI → `lotus/`
 - Agent runtime / Rust 后端 → `bamboo/`
-- 服务端 / Go backend → `bodhi-server/`
+- 可选托管账号 / 凭据 / 路由 / 计费服务 → `bodhi-server/`
 - 官网 / 文档 / 对外内容 → `pavilion/`
+- 共享记忆 MCP → `jiandu/`
+- 电脑操作 MCP → `nova/`
+- 实验性下一代界面 → `lotus-next/`
+- IM 连接器 / Bamboo service plugin → `magpie/`
 
 ### 2. 这套栈为什么这样分
 
 核心产品链路按层拆分，让每一层都能独立演进，又能在发布时收敛成一个产品：
 
-- **界面与体验** 放在 Lotus（React/Vite），可以独立迭代、独立测试。
-- **执行逻辑** 放在 Bamboo（Rust），本地优先、可单独跑成 HTTP 服务。
-- **账号、配额、计费、LLM 代理** 放在 Bodhi Server（Go），把需要服务端信任的能力集中起来。`bodhi-server/internal/` 下能看到 `auth`、`quota`、`pricing`、`proxy`、`database` 等真实模块。
-- **桌面壳** 放在 Bodhi，只负责“把界面装进一个可安装的桌面 App”。
+- **界面与体验** 放在 Lotus（React/Vite）；请求走 HTTP，实时事件默认复用一条共享 WebSocket，并保留 legacy SSE fallback。
+- **执行逻辑与生产界面托管** 放在 Bamboo（Rust），本地优先、可单独运行。
+- **可选托管账号、凭据、模型路由、配额/计费与 provider proxy** 在配置使用时由 Bodhi Server（Go）提供；本地 Bodhi + Bamboo 链路不依赖它。
+- **桌面壳** 放在 Bodhi：负责原生集成、打包发布与受管 Bamboo sidecar 生命周期；release 构建中的 Lotus 由 Bamboo 提供。
 - **对外叙事** 放在 Pavilion，与代码解耦。
 
-另外四个 submodule 保持独立边界：Jiandu 通过 MCP 提供共享记忆，Nova
-通过 MCP 提供电脑操作，Lotus Next 是响应式前端的后继路线，Magpie
-负责把 IM 平台连接到 Bamboo。
+另外四个 submodule 保持独立边界：Jiandu 是 runtime 无关共享记忆的 Rust
+库与独立 stdio MCP server；Nova 通过 MCP 提供电脑操作；Lotus Next 是与
+Lotus 并行的实验性前端路线，并非当前 Bodhi 默认界面；Magpie 负责把 IM
+平台连接到 Bamboo。
 
 ### 3. 协调发布列车
 
@@ -133,7 +140,7 @@ README 不再复制一份会过期的版本快照。
 |---|---|
 | `release-train.yml` | 协调发布（全量或用 `targets` 部分发车）：Lotus → Bamboo → Bodhi |
 | `nightly-release.yml` | 每天 UTC 04:00（北京时间 12:00）按 `YYYY.M.N` 自动递增版本并触发 |
-| `submodule-guard.yml` | 每次 push / PR 校验 submodule 指针 |
+| `submodule-guard.yml` | 在 push 到 `main` 及目标为 `main` 的 PR 中校验 submodule 指针 |
 
 > **默认策略** —— 正常发布走 Zenith 的 release train；子仓库的独立发布流程仅用于恢复或特殊情况。
 
@@ -157,12 +164,14 @@ git submodule update --init --recursive
 ### 运行桌面产品
 
 ```bash
-cd bodhi
+cd lotus
+npm install
+cd ../bodhi
 npm install
 npm run tauri:dev
 ```
 
-> Bodhi 的 `web:dev` / `tauri:dev` 会驱动 `../lotus` 的 Vite 前端；脚本定义见 `bodhi/package.json`。
+> `tauri:dev` 会把 `../bamboo` 构建为受管 debug sidecar，启动 `../lotus` 的 Vite HMR，再启动 Bodhi。Bodhi 会启动或复用 Bamboo 并等待健康检查，开发界面继续由 Vite 提供；打包构建则加载 Bamboo 提供的 Lotus 前端。脚本定义见 `bodhi/package.json`，运行边界见 [Bodhi README](https://github.com/bigduu/Bodhi-AI)。
 
 ### 单独跑前端
 
@@ -171,6 +180,8 @@ cd lotus
 npm install
 npm run dev
 ```
+
+> Vite 界面可以单独启动；实时 agent 数据仍需要另行运行 Bamboo 服务。
 
 ### 运行执行引擎
 
@@ -207,11 +218,11 @@ git push
 | Bodhi AI — 桌面产品门面 | https://github.com/bigduu/Bodhi-AI |
 | Lotus — React UI 层 | https://github.com/bigduu/Lotus |
 | Bamboo — Rust agent runtime | https://github.com/bigduu/Bamboo-agent |
-| Bodhi Server — Go backend | https://github.com/bigduu/bodhi-server |
+| Bodhi Server — 可选托管账号、凭据、路由、配额/计费与 provider proxy | https://github.com/bigduu/bodhi-server |
 | Pavilion — 官网与文档 | https://github.com/bigduu/Pavilion |
-| Jiandu — 共享记忆 MCP 服务 | https://github.com/bigduu/Jiandu |
+| Jiandu — 文件系统持久化 Rust 记忆库 + stdio MCP server | https://github.com/bigduu/Jiandu |
 | Nova — 电脑操作 MCP 服务 | https://github.com/bigduu/Nova |
-| Lotus Next — 响应式前端后继路线 | https://github.com/bigduu/lotus-next |
+| Lotus Next — 实验性并行前端路线，并非当前 Bodhi 默认界面 | https://github.com/bigduu/lotus-next |
 | Magpie — Bamboo 的 IM 连接器 | https://github.com/bigduu/Magpie |
 
 **关键文档**


### PR DESCRIPTION
## Summary

- Correct the bilingual runtime diagram and prose: Bodhi starts or reuses Bamboo and waits for health; Bamboo serves the embedded Lotus frontend.
- Document HTTP requests plus the shared `/v2/stream` WebSocket as the default live-event path, with legacy SSE only as fallback.
- Mark bodhi-server as an optional hosted service that is not required for local Bodhi + Bamboo operation.
- Describe Jiandu as the small filesystem-backed Rust memory library plus standalone stdio MCP server, without claiming unfinished Bamboo integration.
- Mark Lotus Next as an experimental parallel frontend rather than the current Bodhi default.
- Fix the fresh-clone desktop setup so Lotus dependencies are installed before `tauri:dev`, and explain the managed Bamboo sidecar lifecycle.

## Scope

Only `README.md` and `README.zh-CN.md`.

## Test Plan

- Rendered both complete files with the GitHub GFM Markdown API.
- Verified both language variants keep matching headings, diagrams, module rows, development routes, and quick-start commands.
- Verified all relative link targets and the Jiandu AGENTS anchor exist.
- Scanned for the retired Bodhi-embeds-Lotus, HTTP/SSE-first, mandatory bodhi-server, and Lotus Next successor wording.
- Ran `git diff --check`.
- Complete an independent exact-head review before merge.

Closes #150