### PR TITLE
ci: make Lotus Next the release artifact authority (#231)

### DIFF
--- a/.github/release-train.config.json
+++ b/.github/release-train.config.json
@@ -1,16 +1,48 @@
 {
-  "refs": {
-    "bamboo": "main",
-    "lotus": "main",
-    "bodhi": "main"
+  "schemaVersion": 2,
+  "sources": {
+    "bamboo": {
+      "repository": "bigduu/Bamboo-agent",
+      "workflow": "publish-crate.yml",
+      "ref": "dev",
+      "revision": "a8b5385dc4318ab02ba35c0692bdf48914275f6c",
+      "rootPath": "bamboo"
+    },
+    "bodhi": {
+      "repository": "bigduu/Bodhi-AI",
+      "workflow": "release.yml",
+      "ref": "main",
+      "revision": "d6b3353577ece7587ca3c71aafada076032f2478",
+      "rootPath": "bodhi"
+    }
   },
   "versions": {
-    "release": "2026.9.12",
+    "release": "2026.9.14",
     "bamboo": "2026.9.12",
-    "lotus": "2026.9.12",
     "bodhi": "2026.9.12"
   },
-  "options": {
-    "lotus_skip_tests": false
+  "frontend": {
+    "defaultPackage": "@bigduu/lotus-next",
+    "lotusNext": {
+      "repository": "bigduu/lotus-next",
+      "ref": "main",
+      "rootPath": "lotus-next",
+      "manifestSchemaVersion": 1,
+      "packageName": "@bigduu/lotus-next",
+      "packageVersion": "2026.9.14",
+      "sourceRevision": "ae17b50574ccd86395cbc226b50c9fb2f0f51e0f",
+      "sourceDirty": false,
+      "entrypoint": "index.html",
+      "resourcesSha256": "4e5d67386d6fbef15fc8aaf84238356e86ab470fab5680c33e3d0c28860a7f2d",
+      "manifestSha256": "363cb4f4c763dec5f9337b95f85e1f7ba59ab8f3485e275ec13c10302ffac6c8",
+      "npmShasum": "33e6857ff855c29a14062a460dc88da7b0e9a4e1",
+      "npmIntegrity": "sha512-0elftRZ1eO/oa9RN9AgjkViCmeKbh87YQ+GbTIIeOS2IYYx8A0v9IZf4w2YemxdgR+mfstmc8FnoZYTRQrEbgA=="
+    },
+    "legacyRollback": {
+      "packageName": "@bigduu/lotus",
+      "packageVersion": "2026.8.28",
+      "npmShasum": "33b44396bba7f6ad81ab4c23631ff1f6bd8191e2",
+      "npmIntegrity": "sha512-XHsTmskpprHNSr7w+qwBICZvYsqowdgtQ7H5OcWwjXlzl17M7K91eMGQEMN/LLzD+XGnaWuGlVmiawRknJ2yrg=="
+    }
   }
 }

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -5,12 +5,6 @@ on:
     # UTC 04:00 = 北京时间 12:00 (每天)
     - cron: "0 4 * * *"
   workflow_dispatch:
-    inputs:
-      force:
-        description: "Force release even if already released today"
-        required: false
-        default: false
-        type: boolean
 
 permissions:
   contents: write
@@ -21,7 +15,7 @@ env:
 
 jobs:
   auto-version:
-    name: Calculate next version
+    name: Calculate next downstream version
     runs-on: ubuntu-latest
     outputs:
       new_version: ${{ steps.version.outputs.new_version }}
@@ -31,135 +25,143 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          # Pushes in this job target the current Zenith repository only.
-          # Use the workflow-scoped GitHub token with contents:write instead of the
-          # cross-repo release orchestrator token, which may not have write access here.
           token: ${{ github.token }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Validate committed release authority
+        run: node scripts/release-train-policy.cjs validate --config "${CONFIG_FILE}"
 
       - name: Calculate next version
         id: version
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
-          CURRENT="$(jq -r '.versions.release' "${CONFIG_FILE}")"
-          echo "Current version (Zenith config): ${CURRENT}"
+          current="$(jq -r '.versions.release' "${CONFIG_FILE}")"
+          if ! [[ "${current}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::versions.release must use the numeric YYYY.M.N release sequence."
+            exit 1
+          fi
+          echo "Current downstream release floor: ${current}"
 
-          # Parse current version: YYYY.M.N
-          IFS='.' read -r OLD_YEAR OLD_MONTH OLD_N <<< "${CURRENT}"
-
-          # Current date (UTC)
-          YEAR="$(date -u +%Y)"
-          MONTH="$(date -u +%-m)"
-
-          MAX_N=0
-          if [ "${YEAR}" = "${OLD_YEAR}" ] && [ "${MONTH}" = "${OLD_MONTH}" ]; then
-            MAX_N="${OLD_N}"
+          IFS='.' read -r old_year old_month old_n <<< "${current}"
+          if [ "${#old_n}" -gt 9 ]; then
+            echo "::error::versions.release counter is too large for exact shell arithmetic."
+            exit 1
+          fi
+          year="$(date -u +%Y)"
+          month="$(date -u +%-m)"
+          max_n=0
+          if [ "${year}" = "${old_year}" ] && [ "${month}" = "${old_month}" ]; then
+            max_n="${old_n}"
           fi
 
-          # Ad-hoc or partial releases can publish versions the config never
-          # recorded (and a failed write-back leaves it behind), so also scan
-          # what the registries actually hold for this year.month and advance
-          # past the highest. A registry query failure only logs — the config
-          # floor still applies, and the release train's collision pre-flight
-          # refuses to reuse an occupied version loudly rather than silently.
-          USER_AGENT="zenith-nightly-release/1.0 (+https://github.com/${{ github.repository }})"
-          PATTERN="^${YEAR}\.${MONTH}\.[0-9]+$"
-
-          REMOTE_VERSIONS="$(
+          # A separately staged Lotus Next publication can consume a date-based
+          # version before its downstream lock refresh lands. Scan the canonical
+          # frontend registry along with Bamboo and Bodhi so this train never
+          # reuses any occupied YYYY.M.N number. This does not alter the locked
+          # frontend identity in config.
+          user_agent="zenith-nightly-release/2.0 (+https://github.com/${{ github.repository }})"
+          pattern="^${year}\.${month}\.[0-9]+$"
+          remote_versions="$(
             {
-              curl -sS -H "User-Agent: ${USER_AGENT}" "https://crates.io/api/v1/crates/bamboo-agent" \
+              curl -sS -H "User-Agent: ${user_agent}" \
+                "https://crates.io/api/v1/crates/bamboo-agent" \
                 | jq -r '.versions[].num' || true
-              curl -sS -H "User-Agent: ${USER_AGENT}" "https://registry.npmjs.org/@bigduu%2flotus" \
+              curl -sS -H "User-Agent: ${user_agent}" \
+                "https://registry.npmjs.org/@bigduu%2flotus-next" \
                 | jq -r '.versions | keys[]' || true
               gh release list -R bigduu/Bodhi-AI --limit 100 --json tagName \
                 --jq '.[].tagName | sub("^app-v"; "")' || true
-            } 2>/dev/null | { grep -E "${PATTERN}" || true; } | sort -u
+            } 2>/dev/null | { grep -E "${pattern}" || true; } | sort -u
           )"
 
-          for version in ${REMOTE_VERSIONS}; do
+          for version in ${remote_versions}; do
             n="${version##*.}"
-            if [ "${n}" -gt "${MAX_N}" ]; then
-              echo "Registry already has ${version}; advancing the counter past it"
-              MAX_N="${n}"
+            if [ "${#n}" -gt 9 ]; then
+              echo "::error::Published version ${version} has an unsupported counter size."
+              exit 1
+            fi
+            if [ "${n}" -gt "${max_n}" ]; then
+              echo "Published artifacts already use ${version}; advancing past it."
+              max_n="${n}"
             fi
           done
 
-          NEW_N=$((MAX_N + 1))
-          NEW_VERSION="${YEAR}.${MONTH}.${NEW_N}"
-          echo "New version: ${NEW_VERSION}"
-          echo "new_version=${NEW_VERSION}" >> "${GITHUB_OUTPUT}"
-          echo "should_release=true" >> "${GITHUB_OUTPUT}"
+          new_version="${year}.${month}.$((max_n + 1))"
+          echo "New downstream version: ${new_version}"
+          {
+            echo "new_version=${new_version}"
+            echo "should_release=true"
+          } >> "${GITHUB_OUTPUT}"
 
-      - name: Update release-train.config.json
+      - name: Update downstream version fields
         if: steps.version.outputs.should_release == 'true'
+        shell: bash
         run: |
           set -euo pipefail
-          NEW_VERSION="${{ steps.version.outputs.new_version }}"
+          new_version="${{ steps.version.outputs.new_version }}"
 
-          # Update all version fields in config
-          jq --arg v "${NEW_VERSION}" '
+          jq --arg v "${new_version}" '
             .versions.release = $v |
             .versions.bamboo = $v |
-            .versions.lotus = $v |
             .versions.bodhi = $v
           ' "${CONFIG_FILE}" > "${CONFIG_FILE}.tmp"
           mv "${CONFIG_FILE}.tmp" "${CONFIG_FILE}"
 
-          echo "Updated ${CONFIG_FILE}:"
-          cat "${CONFIG_FILE}"
+          # The frontend object is immutable in this job; schema validation
+          # catches accidental key drift before any commit or dispatch.
+          node scripts/release-train-policy.cjs validate --config "${CONFIG_FILE}"
+          git diff --check
 
-      - name: Commit and push version bump
+      - name: Commit and push downstream version bump
         if: steps.version.outputs.should_release == 'true'
+        shell: bash
         run: |
           set -euo pipefail
-          NEW_VERSION="${{ steps.version.outputs.new_version }}"
+          new_version="${{ steps.version.outputs.new_version }}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-
           git add "${CONFIG_FILE}"
-          git diff --cached --quiet && {
-            echo "No changes to commit (version already up-to-date)."
+          if git diff --cached --quiet; then
+            echo "No downstream version change to commit."
             exit 0
-          }
-
-          git commit -m "chore: bump release version to ${NEW_VERSION} [nightly]"
+          fi
+          git commit -m "chore: bump downstream release version to ${new_version} [nightly]"
           git push
 
   trigger-release-train:
-    name: Trigger Release Train
+    name: Trigger locked-frontend release train
     needs: auto-version
     if: needs.auto-version.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout current main
         uses: actions/checkout@v6
         with:
           ref: main
 
-      - name: Dispatch Release Train
+      - name: Dispatch Bamboo then Bodhi
         env:
-          # This dispatch targets a workflow in the current Zenith repository.
-          # Use the workflow-scoped GitHub token, which now has actions:write.
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          NEW_VERSION="${{ needs.auto-version.outputs.new_version }}"
+          new_version="${{ needs.auto-version.outputs.new_version }}"
+          frontend="$(jq -r '.frontend.defaultPackage + "@" + .frontend.lotusNext.packageVersion' "${CONFIG_FILE}")"
+          echo "Dispatching downstream release ${new_version} with locked frontend ${frontend}."
+          echo "Release order: Bamboo -> Bodhi"
 
-          echo "Dispatching release-train with version ${NEW_VERSION}"
-          echo "Release order: Lotus → Bamboo → Bodhi"
-
-          # The release-train.yml workflow reads from config.json by default
-          # (all inputs default to "from_manifest"), so we just need to trigger it.
-          # The config was already updated in the previous job.
-          #
-          # Override lotus_skip_tests=true for nightly to avoid blocking on tests.
           gh workflow run release-train.yml \
             --ref main \
-            -f release_version="${NEW_VERSION}" \
-            -f lotus_skip_tests=true
+            -f targets=bamboo,bodhi
 
           echo "Release train dispatched. Monitor at:"
           echo "https://github.com/${{ github.repository }}/actions/workflows/release-train.yml"

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -161,7 +161,8 @@ jobs:
 
           gh workflow run release-train.yml \
             --ref main \
-            -f targets=bamboo,bodhi
+            -f targets=bamboo,bodhi \
+            -f release_version="${new_version}"
 
           echo "Release train dispatched. Monitor at:"
           echo "https://github.com/${{ github.repository }}/actions/workflows/release-train.yml"

--- a/.github/workflows/release-policy.yml
+++ b/.github/workflows/release-policy.yml
@@ -1,0 +1,185 @@
+name: Release Policy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/release-train.config.json"
+      - ".github/workflows/release-policy.yml"
+      - ".github/workflows/release-train.yml"
+      - ".github/workflows/nightly-release.yml"
+      - "scripts/release-train-policy.cjs"
+      - "scripts/release-train-policy.test.cjs"
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+    paths:
+      - ".github/release-train.config.json"
+      - ".github/workflows/release-policy.yml"
+      - ".github/workflows/release-train.yml"
+      - ".github/workflows/nightly-release.yml"
+      - "scripts/release-train-policy.cjs"
+      - "scripts/release-train-policy.test.cjs"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate Release Policy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout exact tested source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Run focused policy tests
+        run: node --test scripts/release-train-policy.test.cjs
+
+      - name: Validate workflow syntax
+        shell: bash
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+          ACTIONLINT_SHA256: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+        run: |
+          set -euo pipefail
+          archive="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          download="${RUNNER_TEMP}/${archive}"
+          curl --fail --silent --show-error --location \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${archive}" \
+            --output "${download}"
+          echo "${ACTIONLINT_SHA256}  ${download}" | sha256sum --check -
+          tar --extract --gzip --file "${download}" --directory "${RUNNER_TEMP}" actionlint
+          "${RUNNER_TEMP}/actionlint" -color \
+            .github/workflows/release-policy.yml \
+            .github/workflows/release-train.yml \
+            .github/workflows/nightly-release.yml \
+            .github/workflows/submodule-guard.yml
+
+      - name: Verify accepted root and downstream source revisions
+        shell: bash
+        env:
+          EXPECTED_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          config="${GITHUB_WORKSPACE}/.github/release-train.config.json"
+          resolved="${RUNNER_TEMP}/release-policy.json"
+          test "$(git rev-parse HEAD)" = "${EXPECTED_SHA}"
+
+          node scripts/release-train-policy.cjs resolve \
+            --config "${config}" \
+            --targets bamboo,bodhi \
+            --frontend-package from_manifest \
+            --release-version from_manifest \
+            --bamboo-version from_manifest \
+            --bodhi-version from_manifest \
+            --resume false > "${resolved}"
+
+          verify_root_pointer() {
+            local label="$1"
+            local revision="$2"
+            local root_path="$3"
+            local row mode pointer
+            row="$(git ls-tree HEAD -- "${root_path}")"
+            mode="$(printf '%s\n' "${row}" | awk '{print $1}')"
+            pointer="$(printf '%s\n' "${row}" | awk '{print $3}')"
+            if [ "${mode}" != "160000" ] || [ "${pointer}" != "${revision}" ]; then
+              echo "::error::${label} root pointer ${pointer:-missing} does not match ${revision}."
+              exit 1
+            fi
+          }
+
+          verify_dispatch_source() {
+            local label="$1"
+            local repository="$2"
+            local ref="$3"
+            local revision="$4"
+            local root_path="$5"
+            local remote
+            verify_root_pointer "${label}" "${revision}" "${root_path}"
+            remote="$(git ls-remote --exit-code \
+              "https://github.com/${repository}.git" \
+              "refs/heads/${ref}" | awk 'NR == 1 { print $1 }')"
+            if [ "${remote}" != "${revision}" ]; then
+              echo "::error::${repository}@${ref} is ${remote:-missing}, expected ${revision}."
+              exit 1
+            fi
+          }
+
+          verify_dispatch_source \
+            Bamboo \
+            "$(jq -r .bamboo_repository "${resolved}")" \
+            "$(jq -r .bamboo_ref "${resolved}")" \
+            "$(jq -r .bamboo_revision "${resolved}")" \
+            "$(jq -r .bamboo_root_path "${resolved}")"
+          verify_dispatch_source \
+            Bodhi \
+            "$(jq -r .bodhi_repository "${resolved}")" \
+            "$(jq -r .bodhi_ref "${resolved}")" \
+            "$(jq -r .bodhi_revision "${resolved}")" \
+            "$(jq -r .bodhi_root_path "${resolved}")"
+          verify_root_pointer \
+            "Lotus Next artifact source" \
+            "$(jq -r .lotus_next_revision "${resolved}")" \
+            "$(jq -r .lotus_next_root_path "${resolved}")"
+
+      - name: Round-trip both committed npm artifacts
+        shell: bash
+        env:
+          NPM_CONFIG_AUDIT: "false"
+          NPM_CONFIG_FUND: "false"
+          NPM_CONFIG_PROGRESS: "false"
+          NPM_CONFIG_PREFER_OFFLINE: "false"
+          NPM_CONFIG_CACHE: ${{ runner.temp }}/zenith-release-policy-npm-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          config="${GITHUB_WORKSPACE}/.github/release-train.config.json"
+
+          verify_registry_package() {
+            local package_name="$1"
+            local package_version="$2"
+            local slug="$3"
+            local artifact_dir archive
+            artifact_dir="$(mktemp -d "${RUNNER_TEMP}/${slug}.XXXXXX")"
+            cd "${artifact_dir}"
+
+            npm pack "${package_name}@${package_version}" \
+              --ignore-scripts \
+              --prefer-online \
+              --json > pack.json
+            test "$(jq length pack.json)" = "1"
+            archive="$(jq -r '.[0].filename' pack.json)"
+            test -n "${archive}"
+            test "$(basename "${archive}")" = "${archive}"
+
+            node "${GITHUB_WORKSPACE}/scripts/release-train-policy.cjs" verify-tarball \
+              --config "${config}" \
+              --frontend-package "${package_name}" \
+              --tarball "${archive}"
+            mkdir unpacked
+            tar --extract --gzip --file "${archive}" --directory unpacked --no-same-owner
+            test -d unpacked/package
+            test "$(find unpacked -mindepth 1 -maxdepth 1 | wc -l | tr -d ' ')" = "1"
+            node "${GITHUB_WORKSPACE}/scripts/release-train-policy.cjs" verify-package \
+              --config "${config}" \
+              --frontend-package "${package_name}" \
+              --package-dir unpacked/package
+          }
+
+          verify_registry_package \
+            "$(jq -r .frontend.lotusNext.packageName "${config}")" \
+            "$(jq -r .frontend.lotusNext.packageVersion "${config}")" \
+            lotus-next
+          verify_registry_package \
+            "$(jq -r .frontend.legacyRollback.packageName "${config}")" \
+            "$(jq -r .frontend.legacyRollback.packageVersion "${config}")" \
+            legacy-lotus

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -1,58 +1,49 @@
 name: Release Train
 
-# Orchestrates publishing across the three repos in dependency order:
+# Publishes downstream consumers in dependency order:
 #
-#   Lotus (npm @bigduu/lotus)  ->  Bamboo (crates.io + embeds that Lotus)  ->  Bodhi (app release consuming both)
+#   locked npm frontend -> Bamboo (crates.io) -> Bodhi (desktop release)
 #
-# Gating is event-driven, not time-based: each leg waits for the upstream
-# workflow to finish AND for the artifact to be visible on its registry before
-# the next leg dispatches. The `targets` input releases a subset (a "partial
-# train"), with excluded targets pinned to the last published versions recorded
-# in .github/release-train.config.json.
+# Lotus Next is published and accepted in its own protected producer/consumer
+# sequence. This workflow never publishes a frontend. It verifies one committed
+# npm artifact identity before dispatching Bamboo and Bodhi.
 
 on:
   workflow_dispatch:
     inputs:
       targets:
-        description: "Comma-separated subset of lotus,bamboo,bodhi to release (dependency order is fixed: Lotus -> Bamboo -> Bodhi)"
+        description: "Comma-separated subset of bamboo,bodhi to release (dependency order is fixed: Bamboo -> Bodhi)"
         required: false
-        default: "lotus,bamboo,bodhi"
-      bamboo_ref:
-        description: "Ref for Bamboo release workflow (use 'from_manifest' to read Zenith config)"
-        required: false
-        default: "from_manifest"
-      lotus_ref:
-        description: "Ref for Lotus publish workflow (use 'from_manifest' to read Zenith config)"
-        required: false
-        default: "from_manifest"
-      bodhi_ref:
-        description: "Ref for Bodhi release workflow (use 'from_manifest' to read Zenith config)"
-        required: false
-        default: "from_manifest"
+        default: "bamboo,bodhi"
+        type: string
+      frontend_package:
+        description: "Locked frontend artifact; legacy Lotus is an explicit fixed rollback only"
+        required: true
+        default: "@bigduu/lotus-next"
+        type: choice
+        options:
+          - "@bigduu/lotus-next"
+          - "@bigduu/lotus"
       release_version:
-        description: "Unified version for the included targets (use 'from_manifest' to read .versions.release)"
+        description: "Unified version for included targets (from_manifest reads .versions.release)"
         required: false
         default: "from_manifest"
+        type: string
       bamboo_version:
-        description: "bamboo-agent crate version (use 'from_manifest' to read Zenith config; excluded targets pin to the last recorded published version)"
+        description: "Bamboo crate version (from_manifest uses the unified version when included, otherwise the recorded published version)"
         required: false
         default: "from_manifest"
-      lotus_version:
-        description: "Lotus npm version (use 'from_manifest' to read Zenith config; excluded targets pin to the last recorded published version)"
-        required: false
-        default: "from_manifest"
+        type: string
       bodhi_version:
-        description: "Bodhi app version used for release tag/assets (use 'from_manifest' to read Zenith config)"
+        description: "Bodhi app version (from_manifest uses the unified version when included, otherwise the recorded published version)"
         required: false
         default: "from_manifest"
-      lotus_skip_tests:
-        description: "Pass true to skip Lotus publish workflow tests (use 'from_manifest' to read Zenith config)"
-        required: false
-        default: "from_manifest"
+        type: string
       resume:
-        description: "Pass true to resume a partially completed train at the same versions: already-published targets are skipped instead of failing the collision pre-flight"
+        description: "Resume these exact versions by skipping included artifacts that already exist"
         required: false
-        default: "false"
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -61,205 +52,182 @@ jobs:
   orchestrate:
     runs-on: ubuntu-latest
     outputs:
-      include_lotus: ${{ steps.resolve.outputs.include_lotus }}
       include_bamboo: ${{ steps.resolve.outputs.include_bamboo }}
       include_bodhi: ${{ steps.resolve.outputs.include_bodhi }}
-      lotus_version: ${{ steps.resolve.outputs.lotus_version }}
       bamboo_version: ${{ steps.resolve.outputs.bamboo_version }}
       bodhi_version: ${{ steps.resolve.outputs.bodhi_version }}
     steps:
-      - name: Checkout repository
+      - name: Checkout exact Zenith source
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
-      - name: Resolve release inputs from Zenith config
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Resolve the committed release policy
         id: resolve
+        shell: bash
+        env:
+          TARGETS_INPUT: ${{ inputs.targets }}
+          FRONTEND_PACKAGE_INPUT: ${{ inputs.frontend_package }}
+          RELEASE_VERSION_INPUT: ${{ inputs.release_version }}
+          BAMBOO_VERSION_INPUT: ${{ inputs.bamboo_version }}
+          BODHI_VERSION_INPUT: ${{ inputs.bodhi_version }}
+          RESUME_INPUT: ${{ inputs.resume }}
         run: |
           set -euo pipefail
-          CONFIG_FILE=".github/release-train.config.json"
+          node scripts/release-train-policy.cjs resolve \
+            --config .github/release-train.config.json \
+            --targets "${TARGETS_INPUT}" \
+            --frontend-package "${FRONTEND_PACKAGE_INPUT}" \
+            --release-version "${RELEASE_VERSION_INPUT}" \
+            --bamboo-version "${BAMBOO_VERSION_INPUT}" \
+            --bodhi-version "${BODHI_VERSION_INPUT}" \
+            --resume "${RESUME_INPUT}" \
+            --github-output "${GITHUB_OUTPUT}"
 
-          if [ ! -f "${CONFIG_FILE}" ]; then
-            echo "Missing ${CONFIG_FILE}"
+      - name: Verify exact root pointers and accepted source refs
+        shell: bash
+        env:
+          BAMBOO_REPOSITORY: ${{ steps.resolve.outputs.bamboo_repository }}
+          BAMBOO_REF: ${{ steps.resolve.outputs.bamboo_ref }}
+          BAMBOO_REVISION: ${{ steps.resolve.outputs.bamboo_revision }}
+          BAMBOO_ROOT_PATH: ${{ steps.resolve.outputs.bamboo_root_path }}
+          BODHI_REPOSITORY: ${{ steps.resolve.outputs.bodhi_repository }}
+          BODHI_REF: ${{ steps.resolve.outputs.bodhi_ref }}
+          BODHI_REVISION: ${{ steps.resolve.outputs.bodhi_revision }}
+          BODHI_ROOT_PATH: ${{ steps.resolve.outputs.bodhi_root_path }}
+          LOTUS_NEXT_REPOSITORY: ${{ steps.resolve.outputs.lotus_next_repository }}
+          LOTUS_NEXT_REF: ${{ steps.resolve.outputs.lotus_next_ref }}
+          LOTUS_NEXT_REVISION: ${{ steps.resolve.outputs.lotus_next_revision }}
+          LOTUS_NEXT_ROOT_PATH: ${{ steps.resolve.outputs.lotus_next_root_path }}
+        run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
+            echo "::error::Release Train must run from Zenith main, got ${GITHUB_REF}."
+            exit 1
+          fi
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          test -z "$(git status --porcelain --untracked-files=all)"
+
+          verify_root_pointer() {
+            local label="$1"
+            local revision="$2"
+            local root_path="$3"
+            local row mode pointer
+
+            row="$(git ls-tree HEAD -- "${root_path}")"
+            mode="$(printf '%s\n' "${row}" | awk '{print $1}')"
+            pointer="$(printf '%s\n' "${row}" | awk '{print $3}')"
+            if [ "${mode}" != "160000" ] || [ "${pointer}" != "${revision}" ]; then
+              echo "::error::${label} root pointer ${pointer:-missing} does not match accepted revision ${revision}."
+              exit 1
+            fi
+            echo "Verified ${label} root path ${root_path} at ${revision}."
+          }
+
+          verify_dispatch_source() {
+            local label="$1"
+            local repository="$2"
+            local ref="$3"
+            local revision="$4"
+            local root_path="$5"
+            local remote
+
+            verify_root_pointer "${label}" "${revision}" "${root_path}"
+
+            remote="$(git ls-remote --exit-code \
+              "https://github.com/${repository}.git" \
+              "refs/heads/${ref}" | awk 'NR == 1 { print $1 }')"
+            if [ "${remote}" != "${revision}" ]; then
+              echo "::error::${repository}@${ref} moved from accepted revision ${revision} to ${remote:-missing}."
+              exit 1
+            fi
+            echo "Verified dispatch source ${repository}@${ref} = ${revision}."
+          }
+
+          verify_dispatch_source Bamboo "${BAMBOO_REPOSITORY}" "${BAMBOO_REF}" "${BAMBOO_REVISION}" "${BAMBOO_ROOT_PATH}"
+          verify_dispatch_source Bodhi "${BODHI_REPOSITORY}" "${BODHI_REF}" "${BODHI_REVISION}" "${BODHI_ROOT_PATH}"
+          verify_root_pointer "Lotus Next artifact source" "${LOTUS_NEXT_REVISION}" "${LOTUS_NEXT_ROOT_PATH}"
+          echo "Verified Lotus Next provenance: ${LOTUS_NEXT_REPOSITORY}@${LOTUS_NEXT_REVISION} was accepted from ${LOTUS_NEXT_REF}; the locked artifact remains stable if that branch advances."
+
+      - name: Download and verify the selected frontend artifact
+        shell: bash
+        env:
+          FRONTEND_PACKAGE: ${{ steps.resolve.outputs.frontend_package }}
+          FRONTEND_VERSION: ${{ steps.resolve.outputs.frontend_version }}
+          NPM_CONFIG_AUDIT: "false"
+          NPM_CONFIG_FUND: "false"
+          NPM_CONFIG_PROGRESS: "false"
+          NPM_CONFIG_PREFER_OFFLINE: "false"
+          NPM_CONFIG_CACHE: ${{ runner.temp }}/zenith-release-npm-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          artifact_dir="$(mktemp -d "${RUNNER_TEMP}/frontend-artifact.XXXXXX")"
+          cd "${artifact_dir}"
+
+          npm pack "${FRONTEND_PACKAGE}@${FRONTEND_VERSION}" \
+            --ignore-scripts \
+            --prefer-online \
+            --json > pack.json
+          test "$(jq 'length' pack.json)" = "1"
+          archive="$(jq -r '.[0].filename' pack.json)"
+          if [ -z "${archive}" ] || [ "$(basename "${archive}")" != "${archive}" ]; then
+            echo "::error::npm returned an unsafe tarball filename."
             exit 1
           fi
 
-          jq -e . "${CONFIG_FILE}" >/dev/null
+          node "${GITHUB_WORKSPACE}/scripts/release-train-policy.cjs" verify-tarball \
+            --config "${GITHUB_WORKSPACE}/.github/release-train.config.json" \
+            --frontend-package "${FRONTEND_PACKAGE}" \
+            --tarball "${archive}"
 
-          resolve_value() {
-            local input_value="$1"
-            local jq_path="$2"
-            local resolved
+          mkdir unpacked
+          tar --extract --gzip --file "${archive}" --directory unpacked --no-same-owner
+          test -d unpacked/package
+          test "$(find unpacked -mindepth 1 -maxdepth 1 | wc -l | tr -d ' ')" = "1"
+          node "${GITHUB_WORKSPACE}/scripts/release-train-policy.cjs" verify-package \
+            --config "${GITHUB_WORKSPACE}/.github/release-train.config.json" \
+            --frontend-package "${FRONTEND_PACKAGE}" \
+            --package-dir unpacked/package
 
-            if [ -z "${input_value}" ] || [ "${input_value}" = "from_manifest" ]; then
-              resolved="$(jq -r "${jq_path} | if . == null then empty else . end" "${CONFIG_FILE}")"
-            else
-              resolved="${input_value}"
-            fi
-
-            if [ -z "${resolved}" ] || [ "${resolved}" = "null" ]; then
-              echo "Missing value for ${jq_path} in ${CONFIG_FILE}"
-              exit 1
-            fi
-
-            printf '%s' "${resolved}"
-          }
-
-          TARGETS_INPUT="${{ github.event.inputs.targets }}"
-          if [ -z "${TARGETS_INPUT}" ]; then
-            TARGETS_INPUT="lotus,bamboo,bodhi"
-          fi
-
-          INCLUDE_LOTUS=false
-          INCLUDE_BAMBOO=false
-          INCLUDE_BODHI=false
-          IFS=',' read -ra TARGET_LIST <<< "${TARGETS_INPUT}"
-          for target in "${TARGET_LIST[@]}"; do
-            target="$(printf '%s' "${target}" | tr -d '[:space:]')"
-            case "${target}" in
-              lotus) INCLUDE_LOTUS=true ;;
-              bamboo) INCLUDE_BAMBOO=true ;;
-              bodhi) INCLUDE_BODHI=true ;;
-              "") ;;
-              *)
-                echo "Unknown release target '${target}' (expected a comma-separated subset of: lotus, bamboo, bodhi)"
-                exit 1
-                ;;
-            esac
-          done
-
-          if [ "${INCLUDE_LOTUS}" = "false" ] && [ "${INCLUDE_BAMBOO}" = "false" ] && [ "${INCLUDE_BODHI}" = "false" ]; then
-            echo "targets='${TARGETS_INPUT}' selected nothing to release"
-            exit 1
-          fi
-
-          RESUME="$(printf '%s' "${{ github.event.inputs.resume }}" | tr '[:upper:]' '[:lower:]')"
-          if [ -z "${RESUME}" ]; then
-            RESUME=false
-          fi
-          case "${RESUME}" in
-            true|false) ;;
-            *)
-              echo "resume must be true or false, got: ${RESUME}"
-              exit 1
-              ;;
-          esac
-
-          BAMBOO_REF="$(resolve_value "${{ github.event.inputs.bamboo_ref }}" '.refs.bamboo')"
-          LOTUS_REF="$(resolve_value "${{ github.event.inputs.lotus_ref }}" '.refs.lotus')"
-          BODHI_REF="$(resolve_value "${{ github.event.inputs.bodhi_ref }}" '.refs.bodhi')"
-
-          RELEASE_VERSION_INPUT="${{ github.event.inputs.release_version }}"
-          if [ -z "${RELEASE_VERSION_INPUT}" ] || [ "${RELEASE_VERSION_INPUT}" = "from_manifest" ]; then
-            RELEASE_VERSION="$(jq -r '.versions.release // empty' "${CONFIG_FILE}")"
-          else
-            RELEASE_VERSION="${RELEASE_VERSION_INPUT}"
-          fi
-
-          # Included targets publish at the unified release version; excluded
-          # targets pin to the last recorded published version so partial
-          # trains consume real artifacts instead of the new (unpublished)
-          # release number. An explicit per-repo input always wins.
-          resolve_component_version() {
-            local input_value="$1"
-            local included="$2"
-            local jq_path="$3"
-
-            if [ -n "${input_value}" ] && [ "${input_value}" != "from_manifest" ]; then
-              printf '%s' "${input_value}"
-              return
-            fi
-
-            if [ "${included}" = "true" ] && [ -n "${RELEASE_VERSION}" ] && [ "${RELEASE_VERSION}" != "null" ]; then
-              printf '%s' "${RELEASE_VERSION}"
-              return
-            fi
-
-            resolve_value "" "${jq_path}"
-          }
-
-          BAMBOO_VERSION="$(resolve_component_version "${{ github.event.inputs.bamboo_version }}" "${INCLUDE_BAMBOO}" '.versions.bamboo')"
-          LOTUS_VERSION="$(resolve_component_version "${{ github.event.inputs.lotus_version }}" "${INCLUDE_LOTUS}" '.versions.lotus')"
-          BODHI_VERSION="$(resolve_component_version "${{ github.event.inputs.bodhi_version }}" "${INCLUDE_BODHI}" '.versions.bodhi')"
-
-          LOTUS_SKIP_TESTS="$(resolve_value "${{ github.event.inputs.lotus_skip_tests }}" '.options.lotus_skip_tests')"
-
-          case "${LOTUS_SKIP_TESTS}" in
-            true|false) ;;
-            *)
-              echo "lotus_skip_tests must be true or false, got: ${LOTUS_SKIP_TESTS}"
-              exit 1
-              ;;
-          esac
-
-          {
-            echo "include_lotus=${INCLUDE_LOTUS}"
-            echo "include_bamboo=${INCLUDE_BAMBOO}"
-            echo "include_bodhi=${INCLUDE_BODHI}"
-            echo "resume=${RESUME}"
-            echo "bamboo_ref=${BAMBOO_REF}"
-            echo "lotus_ref=${LOTUS_REF}"
-            echo "bodhi_ref=${BODHI_REF}"
-            echo "release_version=${RELEASE_VERSION}"
-            echo "bamboo_version=${BAMBOO_VERSION}"
-            echo "lotus_version=${LOTUS_VERSION}"
-            echo "bodhi_version=${BODHI_VERSION}"
-            echo "lotus_skip_tests=${LOTUS_SKIP_TESTS}"
-          } >> "${GITHUB_OUTPUT}"
-
-          cat <<EOF
-          Resolved release inputs:
-          - targets: lotus=${INCLUDE_LOTUS} bamboo=${INCLUDE_BAMBOO} bodhi=${INCLUDE_BODHI} (resume=${RESUME})
-          - bamboo_ref=${BAMBOO_REF}
-          - lotus_ref=${LOTUS_REF}
-          - bodhi_ref=${BODHI_REF}
-          - release_version=${RELEASE_VERSION}
-          - bamboo_version=${BAMBOO_VERSION}
-          - lotus_version=${LOTUS_VERSION}
-          - bodhi_version=${BODHI_VERSION}
-          - lotus_skip_tests=${LOTUS_SKIP_TESTS}
-          EOF
-
-      - name: Validate release token
+      - name: Validate cross-repository release token
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.RELEASE_ORCHESTRATOR_TOKEN }}
         run: |
-          if [ -z "${GH_TOKEN}" ]; then
-            echo "Missing RELEASE_ORCHESTRATOR_TOKEN secret."
-            echo "Create a token with permissions to run and read workflows in:"
-            echo "- bigduu/Bamboo-agent"
-            echo "- bigduu/Lotus"
-            echo "- bigduu/Bodhi-AI"
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::Missing RELEASE_ORCHESTRATOR_TOKEN secret."
+            echo "It must be able to dispatch and read workflows in the accepted Bamboo and Bodhi repositories."
             exit 1
           fi
 
-      - name: Pre-flight version checks
+      - name: Check downstream version collisions
         id: preflight
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.RELEASE_ORCHESTRATOR_TOKEN }}
-          INCLUDE_LOTUS: ${{ steps.resolve.outputs.include_lotus }}
           INCLUDE_BAMBOO: ${{ steps.resolve.outputs.include_bamboo }}
           INCLUDE_BODHI: ${{ steps.resolve.outputs.include_bodhi }}
           RESUME: ${{ steps.resolve.outputs.resume }}
-          LOTUS_VERSION: ${{ steps.resolve.outputs.lotus_version }}
           BAMBOO_VERSION: ${{ steps.resolve.outputs.bamboo_version }}
           BODHI_VERSION: ${{ steps.resolve.outputs.bodhi_version }}
         run: |
           set -euo pipefail
-
-          USER_AGENT="zenith-release-train/1.0 (+https://github.com/${{ github.repository }})"
+          user_agent="zenith-release-train/2.0 (+https://github.com/${{ github.repository }})"
 
           crates_version_exists() {
             local status
             status="$(curl -sS -o /dev/null -w "%{http_code}" \
-              -H "User-Agent: ${USER_AGENT}" \
+              -H "User-Agent: ${user_agent}" \
               "https://crates.io/api/v1/crates/bamboo-agent/$1" || true)"
-            [ "${status}" = "200" ]
-          }
-
-          npm_version_exists() {
-            local status
-            status="$(curl -sS -o /dev/null -w "%{http_code}" \
-              -H "User-Agent: ${USER_AGENT}" \
-              "https://registry.npmjs.org/@bigduu%2flotus/$1" || true)"
             [ "${status}" = "200" ]
           }
 
@@ -267,133 +235,142 @@ jobs:
             gh release view "app-v$1" -R bigduu/Bodhi-AI >/dev/null 2>&1
           }
 
-          SKIP_LOTUS=false
-          SKIP_BAMBOO=false
-          SKIP_BODHI=false
+          skip_bamboo=false
+          skip_bodhi=false
 
-          # Included targets must not collide with an already-published
-          # version. Both downstream publish workflows treat "already exists"
-          # as success (for retries), so without this check a collision would
-          # silently keep the stale artifact and report a green train.
           check_collision() {
-            local name="$1" version="$2" exists_fn="$3" skip_var="$4"
-            if [ "${version}" = "latest" ]; then
-              return 0
-            fi
+            local name="$1"
+            local version="$2"
+            local exists_fn="$3"
+            local skip_var="$4"
             if "${exists_fn}" "${version}"; then
               if [ "${RESUME}" = "true" ]; then
-                echo "${name}@${version} already published; resume=true -> skipping this leg."
-                eval "${skip_var}=true"
+                echo "${name}@${version} already exists; resume=true skips this leg."
+                printf -v "${skip_var}" '%s' true
               else
-                echo "::error::${name}@${version} is already published. An ad-hoc release may have consumed this number; pick an unused version, or pass resume=true to resume a partial train at these exact versions."
+                echo "::error::${name}@${version} already exists. Choose an unused version or resume this exact partial train."
                 exit 1
               fi
             fi
           }
 
-          if [ "${INCLUDE_LOTUS}" = "true" ]; then
-            check_collision "@bigduu/lotus" "${LOTUS_VERSION}" npm_version_exists SKIP_LOTUS
-          fi
-          if [ "${INCLUDE_BAMBOO}" = "true" ]; then
-            check_collision "bamboo-agent" "${BAMBOO_VERSION}" crates_version_exists SKIP_BAMBOO
-          fi
-          if [ "${INCLUDE_BODHI}" = "true" ]; then
-            check_collision "Bodhi app release" "${BODHI_VERSION}" bodhi_release_exists SKIP_BODHI
-          fi
-
-          # Versions consumed from excluded targets must actually exist —
-          # a partial train must never point a release at a phantom artifact.
           require_exists() {
-            local desc="$1" version="$2" exists_fn="$3"
-            if [ "${version}" = "latest" ]; then
-              return 0
-            fi
+            local name="$1"
+            local version="$2"
+            local exists_fn="$3"
             if ! "${exists_fn}" "${version}"; then
-              echo "::error::${desc}@${version} is not published, but an included target depends on it and its producer is not in targets. Release it first or fix the version."
+              echo "::error::${name}@${version} is required by an included target but is not published."
               exit 1
             fi
           }
 
-          if [ "${INCLUDE_BAMBOO}" = "true" ] && [ "${INCLUDE_LOTUS}" != "true" ]; then
-            require_exists "@bigduu/lotus" "${LOTUS_VERSION}" npm_version_exists
+          if [ "${INCLUDE_BAMBOO}" = "true" ]; then
+            check_collision bamboo-agent "${BAMBOO_VERSION}" crates_version_exists skip_bamboo
           fi
           if [ "${INCLUDE_BODHI}" = "true" ]; then
-            if [ "${INCLUDE_LOTUS}" != "true" ]; then
-              require_exists "@bigduu/lotus" "${LOTUS_VERSION}" npm_version_exists
-            fi
+            check_collision "Bodhi app release" "${BODHI_VERSION}" bodhi_release_exists skip_bodhi
             if [ "${INCLUDE_BAMBOO}" != "true" ]; then
-              require_exists "bamboo-agent" "${BAMBOO_VERSION}" crates_version_exists
+              require_exists bamboo-agent "${BAMBOO_VERSION}" crates_version_exists
             fi
           fi
 
           {
-            echo "skip_lotus=${SKIP_LOTUS}"
-            echo "skip_bamboo=${SKIP_BAMBOO}"
-            echo "skip_bodhi=${SKIP_BODHI}"
+            echo "skip_bamboo=${skip_bamboo}"
+            echo "skip_bodhi=${skip_bodhi}"
           } >> "${GITHUB_OUTPUT}"
+          echo "Downstream preflight passed (skip: bamboo=${skip_bamboo} bodhi=${skip_bodhi})."
 
-          echo "Pre-flight passed (skip: lotus=${SKIP_LOTUS} bamboo=${SKIP_BAMBOO} bodhi=${SKIP_BODHI})"
-
-      - name: Run Lotus -> Bamboo -> Bodhi
+      - name: Run Bamboo then Bodhi
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.RELEASE_ORCHESTRATOR_TOKEN }}
-          INCLUDE_LOTUS: ${{ steps.resolve.outputs.include_lotus }}
           INCLUDE_BAMBOO: ${{ steps.resolve.outputs.include_bamboo }}
           INCLUDE_BODHI: ${{ steps.resolve.outputs.include_bodhi }}
-          SKIP_LOTUS: ${{ steps.preflight.outputs.skip_lotus }}
           SKIP_BAMBOO: ${{ steps.preflight.outputs.skip_bamboo }}
           SKIP_BODHI: ${{ steps.preflight.outputs.skip_bodhi }}
+          BAMBOO_REPOSITORY: ${{ steps.resolve.outputs.bamboo_repository }}
+          BAMBOO_WORKFLOW: ${{ steps.resolve.outputs.bamboo_workflow }}
           BAMBOO_REF: ${{ steps.resolve.outputs.bamboo_ref }}
-          LOTUS_REF: ${{ steps.resolve.outputs.lotus_ref }}
+          BAMBOO_REVISION: ${{ steps.resolve.outputs.bamboo_revision }}
+          BODHI_REPOSITORY: ${{ steps.resolve.outputs.bodhi_repository }}
+          BODHI_WORKFLOW: ${{ steps.resolve.outputs.bodhi_workflow }}
           BODHI_REF: ${{ steps.resolve.outputs.bodhi_ref }}
+          BODHI_REVISION: ${{ steps.resolve.outputs.bodhi_revision }}
           BAMBOO_VERSION: ${{ steps.resolve.outputs.bamboo_version }}
-          LOTUS_VERSION: ${{ steps.resolve.outputs.lotus_version }}
           BODHI_VERSION: ${{ steps.resolve.outputs.bodhi_version }}
-          LOTUS_SKIP_TESTS: ${{ steps.resolve.outputs.lotus_skip_tests }}
+          FRONTEND_PACKAGE: ${{ steps.resolve.outputs.frontend_package }}
+          FRONTEND_VERSION: ${{ steps.resolve.outputs.frontend_version }}
         run: |
           set -euo pipefail
 
+          assert_remote_ref() {
+            local repository="$1"
+            local ref="$2"
+            local revision="$3"
+            local remote
+            remote="$(git ls-remote --exit-code \
+              "https://github.com/${repository}.git" \
+              "refs/heads/${ref}" | awk 'NR == 1 { print $1 }')"
+            if [ "${remote}" != "${revision}" ]; then
+              echo "::error::${repository}@${ref} moved from accepted revision ${revision} to ${remote:-missing} before dispatch."
+              exit 1
+            fi
+          }
+
           dispatch_and_wait() {
-            local repo="$1"
+            local repository="$1"
             local workflow="$2"
             local ref="$3"
-            shift 3
+            local revision="$4"
+            shift 4
 
+            assert_remote_ref "${repository}" "${ref}" "${revision}"
             local start_epoch
             start_epoch="$(date -u +%s)"
 
-            echo "Dispatching ${workflow} on ${repo}@${ref}"
-            local cmd=(gh workflow run "${workflow}" -R "${repo}" --ref "${ref}")
+            echo "Dispatching ${repository}:${workflow} at accepted ${ref}=${revision}"
+            local command=(gh workflow run "${workflow}" -R "${repository}" --ref "${ref}")
             for input in "$@"; do
-              cmd+=(-f "${input}")
+              command+=(-f "${input}")
             done
-            "${cmd[@]}"
+            "${command[@]}"
 
             local run_id=""
+            local recent_runs=""
+            local wrong_head=""
             for _ in $(seq 1 90); do
-              run_id="$(gh run list \
-                -R "${repo}" \
+              recent_runs="$(gh run list \
+                -R "${repository}" \
                 --workflow "${workflow}" \
                 --event workflow_dispatch \
                 --branch "${ref}" \
                 --limit 20 \
-                --json databaseId,createdAt \
-                --jq "[.[] | select((.createdAt | fromdateiso8601) >= ${start_epoch})] | first | .databaseId // empty")"
-
+                --json databaseId,createdAt,headSha)"
+              run_id="$(printf '%s' "${recent_runs}" | jq -r \
+                --arg revision "${revision}" \
+                --argjson start "${start_epoch}" \
+                '[.[] | select((.createdAt | fromdateiso8601) >= $start and .headSha == $revision)] | first | .databaseId // empty')"
               if [ -n "${run_id}" ]; then
                 break
+              fi
+              wrong_head="$(printf '%s' "${recent_runs}" | jq -r \
+                --arg revision "${revision}" \
+                --argjson start "${start_epoch}" \
+                '[.[] | select((.createdAt | fromdateiso8601) >= $start and .headSha != $revision)] | first | .headSha // empty')"
+              if [ -n "${wrong_head}" ]; then
+                echo "::error::Dispatched ${repository}:${workflow} resolved to unexpected head ${wrong_head}, not ${revision}."
+                exit 1
               fi
               sleep 5
             done
 
             if [ -z "${run_id}" ]; then
-              echo "Unable to find workflow run for ${repo}:${workflow}"
+              echo "::error::Unable to find the exact dispatched run for ${repository}:${workflow}@${revision}."
               exit 1
             fi
-
-            echo "Watching run ${run_id} for ${repo}:${workflow}"
-            gh run watch "${run_id}" -R "${repo}" --interval 20 --exit-status
-            echo "Completed ${repo}:${workflow}"
+            test "$(gh run view "${run_id}" -R "${repository}" --json headSha --jq .headSha)" = "${revision}"
+            echo "Watching exact run ${run_id} for ${repository}:${workflow}@${revision}"
+            gh run watch "${run_id}" -R "${repository}" --interval 20 --exit-status
           }
 
           wait_for_crates_version() {
@@ -401,179 +378,137 @@ jobs:
             local version="$2"
             local max_attempts=30
             local attempt=1
-            local url
-            local http_status
+            local url="https://crates.io/api/v1/crates/${crate_name}/${version}"
+            local status
 
-            if [ "${version}" = "latest" ]; then
-              return 0
-            fi
-
-            url="https://crates.io/api/v1/crates/${crate_name}/${version}"
-            echo "Validating crates.io availability: ${crate_name}@${version}"
+            echo "Waiting for ${crate_name}@${version} on crates.io."
             while [ "${attempt}" -le "${max_attempts}" ]; do
-              http_status="$(curl -sS -o /dev/null -w "%{http_code}" \
-                -H "User-Agent: zenith-release-train/1.0 (+https://github.com/bigduu/Zenith)" \
+              status="$(curl -sS -o /dev/null -w "%{http_code}" \
+                -H "User-Agent: zenith-release-train/2.0 (+https://github.com/bigduu/Zenith)" \
                 "${url}" || true)"
-              if [ "${http_status}" = "200" ]; then
-                echo "Found ${crate_name}@${version} on crates.io"
+              if [ "${status}" = "200" ]; then
+                echo "Found ${crate_name}@${version} on crates.io."
                 return 0
               fi
-              echo "Attempt ${attempt}/${max_attempts}: ${crate_name}@${version} not visible on crates.io yet (status=${http_status}); retrying in 10s..."
+              echo "Attempt ${attempt}/${max_attempts}: status=${status}; retrying in 10 seconds."
               attempt=$((attempt + 1))
               sleep 10
             done
-
-            echo "Unable to find ${crate_name}@${version} on crates.io."
-            echo "Bamboo publish workflow publishes the requested workflow input version."
-            echo "Set release_version/bamboo_version to an unused semantic version and retry."
+            echo "::error::Unable to find ${crate_name}@${version} on crates.io."
             exit 1
           }
-
-          wait_for_npm_version() {
-            local package_path_escaped="$1"
-            local version="$2"
-            local max_attempts=30
-            local attempt=1
-            local url
-            local http_status
-
-            if [ "${version}" = "latest" ]; then
-              return 0
-            fi
-
-            url="https://registry.npmjs.org/${package_path_escaped}/${version}"
-            echo "Validating npm availability: ${package_path_escaped/@/%40}@${version}"
-            while [ "${attempt}" -le "${max_attempts}" ]; do
-              http_status="$(curl -sS -o /dev/null -w "%{http_code}" \
-                -H "User-Agent: zenith-release-train/1.0 (+https://github.com/bigduu/Zenith)" \
-                "${url}" || true)"
-              if [ "${http_status}" = "200" ]; then
-                echo "Found ${package_path_escaped/@/%40}@${version} on npm"
-                return 0
-              fi
-              echo "Attempt ${attempt}/${max_attempts}: ${package_path_escaped/@/%40}@${version} not visible on npm yet (status=${http_status}); retrying in 10s..."
-              attempt=$((attempt + 1))
-              sleep 10
-            done
-
-            echo "Unable to find ${package_path_escaped/@/%40}@${version} on npm."
-            echo "Lotus publish workflow publishes the requested workflow input version."
-            echo "Set release_version/lotus_version to an unused semantic version and retry."
-            exit 1
-          }
-
-          # Lotus goes first so Bamboo can embed the exact same-day frontend
-          # (publish-crate.yml installs @bigduu/lotus@<lotus_version> from npm).
-          if [ "${INCLUDE_LOTUS}" = "true" ]; then
-            if [ "${SKIP_LOTUS}" = "true" ]; then
-              echo "Skipping Lotus leg (resume: @bigduu/lotus@${LOTUS_VERSION} is already on npm)."
-            else
-              dispatch_and_wait "bigduu/Lotus" "publish-npm.yml" "${LOTUS_REF}" "version=${LOTUS_VERSION}" "skip_tests=${LOTUS_SKIP_TESTS}"
-              wait_for_npm_version "@bigduu%2flotus" "${LOTUS_VERSION}"
-            fi
-          fi
 
           if [ "${INCLUDE_BAMBOO}" = "true" ]; then
             if [ "${SKIP_BAMBOO}" = "true" ]; then
-              echo "Skipping Bamboo leg (resume: bamboo-agent@${BAMBOO_VERSION} is already on crates.io)."
+              echo "Skipping Bamboo leg because this exact version already exists and resume=true."
             else
-              dispatch_and_wait "bigduu/Bamboo-agent" "publish-crate.yml" "${BAMBOO_REF}" "version=${BAMBOO_VERSION}" "lotus_version=${LOTUS_VERSION}"
-              wait_for_crates_version "bamboo-agent" "${BAMBOO_VERSION}"
+              dispatch_and_wait \
+                "${BAMBOO_REPOSITORY}" \
+                "${BAMBOO_WORKFLOW}" \
+                "${BAMBOO_REF}" \
+                "${BAMBOO_REVISION}" \
+                "version=${BAMBOO_VERSION}" \
+                "frontend_package=${FRONTEND_PACKAGE}" \
+                "lotus_version=${FRONTEND_VERSION}"
+              wait_for_crates_version bamboo-agent "${BAMBOO_VERSION}"
             fi
           fi
 
           if [ "${INCLUDE_BODHI}" = "true" ]; then
             if [ "${SKIP_BODHI}" = "true" ]; then
-              echo "Skipping Bodhi leg (resume: release app-v${BODHI_VERSION} already exists)."
+              echo "Skipping Bodhi leg because this exact release already exists and resume=true."
             else
-              dispatch_and_wait "bigduu/Bodhi-AI" "release.yml" "${BODHI_REF}" "bodhi_version=${BODHI_VERSION}" "bamboo_version=${BAMBOO_VERSION}" "lotus_version=${LOTUS_VERSION}"
+              dispatch_and_wait \
+                "${BODHI_REPOSITORY}" \
+                "${BODHI_WORKFLOW}" \
+                "${BODHI_REF}" \
+                "${BODHI_REVISION}" \
+                "bodhi_version=${BODHI_VERSION}" \
+                "bamboo_version=${BAMBOO_VERSION}" \
+                "bamboo_ref=${BAMBOO_REVISION}" \
+                "frontend_package=${FRONTEND_PACKAGE}" \
+                "lotus_version=${FRONTEND_VERSION}"
             fi
           fi
 
-          echo "Release train completed successfully."
+          echo "Bamboo -> Bodhi release train completed successfully."
 
   record:
-    name: Record published versions
+    name: Record published downstream versions
     needs: orchestrate
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - name: Checkout repository
+      - name: Checkout current Zenith main
         uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
           token: ${{ github.token }}
 
-      - name: Write published versions back to Zenith config
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Record only Bamboo and Bodhi versions
+        shell: bash
         env:
-          INCLUDE_LOTUS: ${{ needs.orchestrate.outputs.include_lotus }}
           INCLUDE_BAMBOO: ${{ needs.orchestrate.outputs.include_bamboo }}
           INCLUDE_BODHI: ${{ needs.orchestrate.outputs.include_bodhi }}
-          LOTUS_VERSION: ${{ needs.orchestrate.outputs.lotus_version }}
           BAMBOO_VERSION: ${{ needs.orchestrate.outputs.bamboo_version }}
           BODHI_VERSION: ${{ needs.orchestrate.outputs.bodhi_version }}
         run: |
           set -euo pipefail
-          CONFIG_FILE=".github/release-train.config.json"
+          config_file=".github/release-train.config.json"
 
-          # Ad-hoc and partial trains would otherwise leave the config behind
-          # reality: the next nightly would recompute an already-consumed
-          # version and the collision pre-flight would stop it. Recording what
-          # was actually published keeps the counter monotonic.
           jq \
-            --arg lotus "${LOTUS_VERSION}" \
             --arg bamboo "${BAMBOO_VERSION}" \
             --arg bodhi "${BODHI_VERSION}" \
-            --argjson inc_lotus "${INCLUDE_LOTUS}" \
-            --argjson inc_bamboo "${INCLUDE_BAMBOO}" \
-            --argjson inc_bodhi "${INCLUDE_BODHI}" \
-            '(if $inc_lotus and $lotus != "latest" then .versions.lotus = $lotus else . end)
-             | (if $inc_bamboo and $bamboo != "latest" then .versions.bamboo = $bamboo else . end)
-             | (if $inc_bodhi and $bodhi != "latest" then .versions.bodhi = $bodhi else . end)' \
-            "${CONFIG_FILE}" > "${CONFIG_FILE}.tmp"
-          mv "${CONFIG_FILE}.tmp" "${CONFIG_FILE}"
+            --argjson include_bamboo "${INCLUDE_BAMBOO}" \
+            --argjson include_bodhi "${INCLUDE_BODHI}" \
+            '(if $include_bamboo then .versions.bamboo = $bamboo else . end)
+             | (if $include_bodhi then .versions.bodhi = $bodhi else . end)' \
+            "${config_file}" > "${config_file}.tmp"
+          mv "${config_file}.tmp" "${config_file}"
 
-          # Advance the unified release counter past every version this train
-          # published so the nightly bump never reuses one of them.
-          CANDIDATES="$(jq -r '.versions.release' "${CONFIG_FILE}")"
-          for entry in "${INCLUDE_LOTUS}:${LOTUS_VERSION}" "${INCLUDE_BAMBOO}:${BAMBOO_VERSION}" "${INCLUDE_BODHI}:${BODHI_VERSION}"; do
+          candidates="$(jq -r '.versions.release' "${config_file}")"
+          for entry in \
+            "${INCLUDE_BAMBOO}:${BAMBOO_VERSION}" \
+            "${INCLUDE_BODHI}:${BODHI_VERSION}"; do
             included="${entry%%:*}"
             version="${entry#*:}"
-            if [ "${included}" = "true" ] && [ "${version}" != "latest" ]; then
-              CANDIDATES="${CANDIDATES}
+            if [ "${included}" = "true" ]; then
+              candidates="${candidates}
           ${version}"
             fi
           done
-          NEW_RELEASE="$(printf '%s\n' "${CANDIDATES}" | tr -d ' ' | sort -V | tail -1)"
-          jq --arg release "${NEW_RELEASE}" '.versions.release = $release' "${CONFIG_FILE}" > "${CONFIG_FILE}.tmp"
-          mv "${CONFIG_FILE}.tmp" "${CONFIG_FILE}"
+          new_release="$(printf '%s\n' "${candidates}" | tr -d ' ' | sort -V | tail -1)"
+          jq --arg release "${new_release}" '.versions.release = $release' \
+            "${config_file}" > "${config_file}.tmp"
+          mv "${config_file}.tmp" "${config_file}"
 
-          echo "Updated ${CONFIG_FILE}:"
-          cat "${CONFIG_FILE}"
+          node scripts/release-train-policy.cjs validate --config "${config_file}"
+          git diff --check
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          git add "${CONFIG_FILE}"
+          git add "${config_file}"
           if git diff --cached --quiet; then
-            echo "Config already records these versions; nothing to write back."
+            echo "Config already records these downstream versions."
             exit 0
           fi
-
           git commit -m "chore: record published versions (release train run ${{ github.run_id }})"
 
-          # main receives concurrent automation commits (nightly bump, pointer
-          # bumps) — rebase and retry instead of failing on the first reject.
           for attempt in 1 2 3 4 5; do
             if git push origin HEAD:main; then
               exit 0
             fi
-            echo "Push rejected (attempt ${attempt}/5); rebasing onto latest main and retrying..."
+            echo "Push rejected (attempt ${attempt}/5); rebasing onto current main."
             git pull --rebase origin main
             sleep 5
           done
-
-          echo "Failed to push the version write-back after 5 attempts."
+          echo "::error::Failed to record versions after five push attempts."
           exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,39 +218,46 @@ Use this checklist for every release train. The only normal release entrypoint i
 
 1. Land release changes through each repository's protected pull-request flow:
    - Use isolated branches/worktrees and Conventional Commits; never push feature or release-preparation commits directly to `main`.
-   - Bamboo feature PRs target `dev`. Release only commits that have reached the canonical ref selected in `.github/release-train.config.json`.
+   - Lotus Next publication is a separate protected producer step. Accept its exact npm identity in Bamboo and Bodhi first, then pin the resulting source commits and artifact identity in a focused Zenith PR.
+   - Bamboo feature PRs target `dev`. Release only the exact Bamboo and Bodhi revisions recorded in `.github/release-train.config.json` and pinned by the matching Zenith gitlinks.
    - If Zenith submodule pointers or release configuration change, update them in a focused Zenith PR after the submodule commits are merged.
 
 2. Run release gates against the exact candidate refs:
    - `cd bamboo && cargo fmt --check && cargo clippy && cargo test`
-   - `cd lotus && npm run type-check && npm run test:run && npm run lint`
+   - `cd lotus-next && npm run verify && npm run test:e2e:built` for a new frontend artifact; its own publish workflow also performs a real Bamboo round trip.
    - `cd bodhi && npm run web:verify:migration && npm run web:verify:docs-boundary`
+   - For release-policy changes: `node --test scripts/release-train-policy.test.cjs` and `actionlint .github/workflows/release-policy.yml .github/workflows/release-train.yml .github/workflows/nightly-release.yml`.
    - If website changed: `cd pavilion && npm run lint && npm run build`
-   - For cross-page UI or workflow changes, also run `cd lotus && npm run test:e2e`.
+   - For cross-page UI changes, run the affected Lotus Next browser suite.
 
 3. Resolve the release version without editing package manifests:
-   - Bamboo, Lotus, and Bodhi source manifests intentionally keep `0.0.0` placeholders. Their publish workflows stamp the requested release version in the temporary publishing checkout.
+   - Bamboo and Bodhi source manifests intentionally keep `0.0.0` placeholders. Their publish workflows stamp the requested downstream release version in temporary publishing checkouts.
+   - The frontend version is not derived from the downstream release number. The train downloads the exact committed npm package/version and verifies its tarball plus, for Lotus Next, its full universal manifest before dispatch.
    - For a config-driven release, update `.github/release-train.config.json` through a focused Zenith PR or let the nightly workflow advance it.
-   - For an ad-hoc release, pass an unused `release_version` to the release train; do not commit version bumps in submodules.
+   - For an ad-hoc release, pass an unused `release_version`; do not edit submodule manifests or the committed frontend identity.
 
 4. Trigger the release train:
    - Config-driven full train: `gh workflow run release-train.yml -R bigduu/Zenith --ref main`.
    - Ad-hoc full train: `gh workflow run release-train.yml -R bigduu/Zenith --ref main -f release_version=<version>`.
-   - Add `-f targets=lotus,bamboo` (or another dependency-ordered subset) for a partial release.
+   - Add `-f targets=bamboo` or `-f targets=bodhi` for a partial release.
+   - The default frontend is the locked Lotus Next artifact. The only rollback selector is `-f frontend_package=@bigduu/lotus`, which still resolves to the one fixed legacy version in config.
 
 5. Watch and verify the release chain:
    - `gh run watch <root_run_id> -R bigduu/Zenith --exit-status`
    - `gh run list -R bigduu/Bamboo-agent --workflow publish-crate.yml --limit 1`
-   - `gh run list -R bigduu/Lotus --workflow publish-npm.yml --limit 1`
-   - `gh run list -R bigduu/Bodhi --workflow release.yml --limit 1`
+   - `gh run list -R bigduu/Bodhi-AI --workflow release.yml --limit 1`
+   - Confirm the downstream runs' `headSha` values equal the accepted revisions in config.
 
 6. Handle failures without changing the release order:
-   - If Bodhi Linux fails with npm `ETARGET` for Lotus:
-     - Wait until `npm view @bigduu/lotus@<version> version` succeeds.
-     - Rerun failed jobs only: `gh run rerun <bodhi_run_id> -R bigduu/Bodhi --failed`.
-   - If root release train fails due transient GitHub API issues, resume the chain manually in the same Bamboo -> Lotus -> Bodhi order.
+   - If locked frontend verification fails, stop. Do not edit a digest to fit registry bytes; publish and accept a new Lotus Next artifact through the staged producer → consumer → Zenith-pointer sequence.
+   - If Bodhi fails with npm `ETARGET`:
+     - Wait until `npm view <configured-package>@<configured-version> version` succeeds.
+     - Rerun failed jobs only: `gh run rerun <bodhi_run_id> -R bigduu/Bodhi-AI --failed`.
+   - If a partial train fails after publishing one downstream artifact, rerun the same versions with `resume=true`. Never substitute a moving `latest`.
+   - If the root train fails due a transient GitHub API issue, resume in the same Bamboo → Bodhi order and retain the exact accepted refs.
 
 7. Run post-release checks:
    - `git status -sb` at root and inside all submodules (must be clean).
-   - `npm view @bigduu/lotus@<version> version`
+   - Verify the configured frontend package/version still reports the committed npm shasum and integrity.
    - `cargo search bamboo-agent --limit 1` (confirm expected version is published)
+   - `gh release view app-v<version> -R bigduu/Bodhi-AI`

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Zenith is its home base: the desktop product, UIs, Rust runtime, optional hosted
 services, shared memory, computer use, IM integration, and docs in one recursive clone.
 
 [![Submodule Guard](https://img.shields.io/github/actions/workflow/status/bigduu/Zenith/submodule-guard.yml?branch=main&label=submodule%20guard&logo=github)](https://github.com/bigduu/Zenith/actions/workflows/submodule-guard.yml)
-[![Release Train](https://img.shields.io/badge/release%20train-Lotus%20→%20Bamboo%20→%20Bodhi-1f6feb)](https://github.com/bigduu/Zenith/actions/workflows/release-train.yml)
+[![Release Train](https://img.shields.io/badge/release%20train-Lotus%20Next%20artifact%20→%20Bamboo%20→%20Bodhi-1f6feb)](https://github.com/bigduu/Zenith/actions/workflows/release-train.yml)
 [![Versioning](https://img.shields.io/badge/versioning-nightly%20YYYY.M.N-8a2be2)](https://github.com/bigduu/Zenith/actions/workflows/nightly-release.yml)
 [![中文 README](https://img.shields.io/badge/lang-中文-red)](./README.zh-CN.md)
 
-**[▶ Start with Bodhi AI](https://github.com/bigduu/Bodhi-AI)** · [Lotus](https://github.com/bigduu/Lotus) · [Bamboo](https://github.com/bigduu/Bamboo-agent) · [Bodhi Server](https://github.com/bigduu/bodhi-server) · [Pavilion](https://github.com/bigduu/Pavilion) · [Architecture Overview](https://github.com/bigduu/Pavilion/blob/main/articles/zenith-architecture-overview.md)
+**[▶ Start with Bodhi AI](https://github.com/bigduu/Bodhi-AI)** · [Lotus Next](https://github.com/bigduu/lotus-next) · [Bamboo](https://github.com/bigduu/Bamboo-agent) · [Bodhi Server](https://github.com/bigduu/bodhi-server) · [Pavilion](https://github.com/bigduu/Pavilion) · [Architecture Overview](https://github.com/bigduu/Pavilion/blob/main/articles/zenith-architecture-overview.md)
 
 </div>
 
@@ -27,7 +27,7 @@ services, shared memory, computer use, IM integration, and docs in one recursive
 |---|---|
 | **A map of the whole system** | One repo shows how product, UI, runtime, backend, and docs divide the work and fit together |
 | **Nine submodules, one clone** | Pull the full product stack and companion services in a single recursive clone |
-| **Coordinated release train** | Lotus → Bamboo → Bodhi published in dependency order, all driven by one config file |
+| **Coordinated release train** | One verified Lotus Next artifact feeds Bamboo → Bodhi in dependency order, all driven by one fail-closed config |
 | **Daily nightly versioning** | Calendar-versioned (`YYYY.M.N`) auto-bump and nightly release |
 | **Submodule guard** | CI validates submodule pointers on pushes to and pull requests targeting `main` |
 | **Clear "start here" routing** | Whether you want the product, the frontend, or the runtime, there is a clear door in |
@@ -43,37 +43,37 @@ graph TD
   Z["Zenith (this repo)<br/>submodule pointers + release train"]
 
   Z --> B["Bodhi AI<br/>desktop product surface (Tauri shell)"]
-  Z --> L["Lotus<br/>React + Vite UI layer"]
+  Z --> L["Lotus<br/>fixed legacy rollback"]
   Z --> R["Bamboo<br/>local-first Rust agent runtime"]
   Z --> S["Bodhi Server<br/>optional hosted service"]
   Z --> P["Pavilion<br/>website & docs"]
   Z --> J["Jiandu<br/>Rust memory crate + stdio MCP"]
   Z --> N["Nova<br/>computer-use MCP server"]
-  Z --> LN["Lotus Next<br/>experimental frontend track"]
+  Z --> LN["Lotus Next<br/>canonical responsive UI"]
   Z --> M["Magpie<br/>IM connector for Bamboo"]
 
   B -. starts / reuses / health-checks .-> R
-  R -. packaged builds serve embedded frontend .-> L
-  L -->|HTTP APIs + shared /v2/stream WebSocket| R
-  L -. legacy SSE fallback .-> R
+  R -. packaged builds serve locked frontend .-> LN
+  LN -->|HTTP APIs + shared /v2/stream WebSocket| R
+  L -. explicit rollback only .-> R
   R -. optional /proxy/* when configured .-> S
   P -. explains .-> B
 ```
 
-> **Note** —— Bodhi owns the native desktop shell and the Bamboo sidecar lifecycle: it starts or reuses `bamboo serve` and waits for it to become healthy. Packaged builds load the Lotus UI served by Bamboo; development keeps Lotus on its Vite dev server while Bamboo runs alongside it. Lotus sends requests over HTTP and receives live events through the shared `/v2/stream` WebSocket by default, with legacy SSE only when WebSocket is disabled or its initial connection cannot be established. Bodhi Server is optional for local operation and is used, when configured, for accounts/authentication, credential storage, quota/billing, model routing, and provider proxying.
+> **Note** —— Bodhi owns the native desktop shell and the Bamboo sidecar lifecycle: it starts or reuses `bamboo serve` and waits for it to become healthy. Packaged builds use the exact Lotus Next npm artifact locked by Bamboo, Bodhi, and the Zenith release policy; legacy Lotus remains only an explicit fixed-version rollback. Lotus Next sends requests over HTTP and receives live events through the shared `/v2/stream` WebSocket. Bodhi Server is optional for local operation and is used, when configured, for accounts/authentication, credential storage, quota/billing, model routing, and provider proxying.
 
 ### What each module does
 
 | Module | Path | Role | Start here |
 |---|---|---|---|
 | **Bodhi AI** | `bodhi/` | Product surface: Tauri shell, native integration, packaging, and managed Bamboo sidecar lifecycle | [Bodhi AI](https://github.com/bigduu/Bodhi-AI) |
-| **Lotus** | `lotus/` | UI layer: React + Vite, HTTP requests, shared WebSocket live events, legacy SSE fallback, view state, settings | [Lotus](https://github.com/bigduu/Lotus) |
-| **Bamboo** | `bamboo/` | Execution engine and production Lotus host: local-first Rust runtime with HTTP, WebSocket, and legacy SSE APIs | [Bamboo Agent](https://github.com/bigduu/Bamboo-agent) |
+| **Lotus** | `lotus/` | Frozen legacy React + Vite UI retained only as the fixed rollback package while retirement acceptance remains open | [Lotus](https://github.com/bigduu/Lotus) |
+| **Bamboo** | `bamboo/` | Execution engine and production Lotus Next host: local-first Rust runtime with HTTP, WebSocket, and legacy SSE APIs | [Bamboo Agent](https://github.com/bigduu/Bamboo-agent) |
 | **Bodhi Server** | `bodhi-server/` | Optional hosted Go service: accounts/auth, API keys, encrypted provider credentials, model routing, billing/quota, provider proxy | [Bodhi Server](https://github.com/bigduu/bodhi-server) |
 | **Pavilion** | `pavilion/` | Website & docs: download page, doc center, public narrative | [Pavilion](https://github.com/bigduu/Pavilion) |
 | **Jiandu** | `jiandu/` | Authoritative shared memory: independent filesystem-backed Rust store, embedding-free lexical recall, host-generated Dream snapshot persistence, and one-tool stdio MCP | [Jiandu](https://github.com/bigduu/Jiandu) · [agent guidance](./AGENTS.md#shared-memory-via-jiandu-mcp) · [portable Skill](https://github.com/bigduu/Jiandu/blob/v0.2.0/skills/jiandu-memory/SKILL.md) |
 | **Nova** | `nova/` | Computer use: native desktop interaction exposed through MCP | [Nova](https://github.com/bigduu/Nova) |
-| **Lotus Next** | `lotus-next/` | Experimental parallel UI track: responsive React + Vite rebuild without current feature-parity or production-readiness claims | [Lotus Next](https://github.com/bigduu/lotus-next) |
+| **Lotus Next** | `lotus-next/` | Canonical responsive React + Vite UI and the default frontend artifact consumed by Bamboo and Bodhi releases | [Lotus Next](https://github.com/bigduu/lotus-next) |
 | **Magpie** | `magpie/` | IM integration: standalone connector and Bamboo service plugin | [Magpie](https://github.com/bigduu/Magpie) |
 | **Zenith (root)** | `.` | Coordinator: submodule pointers, root docs, release train | You are here |
 
@@ -92,58 +92,58 @@ Zenith's biggest job is getting any person to the right door fast.
 
 **If you want to build**
 - Desktop product / Tauri shell → `bodhi/`
-- Frontend interaction / React UI → `lotus/`
+- Canonical frontend interaction / React UI → `lotus-next/`
+- Fixed legacy rollback only → `lotus/`
 - Agent runtime / Rust backend → `bamboo/`
 - Optional hosted accounts / credentials / routing / billing → `bodhi-server/`
 - Website / docs / public content → `pavilion/`
 - Shared-memory MCP → `jiandu/`
 - Computer-use MCP → `nova/`
-- Experimental next-generation UI → `lotus-next/`
 - IM connector / Bamboo service plugin → `magpie/`
 
 ### The stack, organized on purpose
 
 The core product path is split so each layer can evolve on its own yet converge into one product at release time:
 
-- **UI & experience** live in Lotus (React/Vite); requests use HTTP and live events use one shared WebSocket by default, with legacy SSE fallback.
+- **UI & experience** live in Lotus Next (React/Vite); requests use HTTP and live events use one shared WebSocket.
 - **Execution and production UI hosting** live in Bamboo (Rust), local-first and runnable as a standalone service.
 - **Optional hosted accounts, credentials, model routing, quota/billing, and provider proxying** live in Bodhi Server (Go) when configured. The local Bodhi + Bamboo path does not require it.
-- **The desktop shell** lives in Bodhi: it owns native integration, packaging, and the managed Bamboo sidecar lifecycle, while Bamboo serves the embedded Lotus frontend in release builds.
+- **The desktop shell** lives in Bodhi: it owns native integration, packaging, and the managed Bamboo sidecar lifecycle, while release builds consume the same exact locked Lotus Next artifact as Bamboo.
 - **Public narrative** lives in Pavilion, decoupled from code.
 
-Four companion submodules keep separate boundaries: Jiandu owns the authoritative
+Three companion submodules keep separate boundaries: Jiandu owns the authoritative
 filesystem memory root, deterministic embedding-free lexical recall, host-generated
 Dream snapshot bytes, and the one-tool stdio MCP server. Hosts choose query terms,
 optional reranking, prompt placement and budgets, and Dream generation and cadence;
 the optional portable Skill teaches this contract but must be explicitly enabled by
-its host. Nova provides computer use over MCP; Lotus Next is an experimental frontend
-track developed alongside Lotus and is not the current Bodhi default; Magpie connects
-IM platforms to Bamboo.
+its host. Nova provides computer use over MCP, and Magpie connects IM platforms to
+Bamboo. Legacy Lotus stays frozen as a bounded rollback until the remaining migration
+acceptance and retirement gates are complete.
 
 ### Coordinated release train
 
-Shipping several repos at once, in dependency order, is error-prone. Zenith reduces it to one config plus one workflow.
+Shipping several repos at once, in dependency order, is error-prone. Zenith reduces it to one reviewed authority file plus one workflow.
 
-The order is fixed by the dependency graph:
+Lotus Next publication is a separate protected producer step. After that artifact has passed its own source review and downstream lock refresh, the release train consumes it without republishing or rewriting it. The downstream order is fixed:
 
-1. **Lotus** → publish npm package `@bigduu/lotus` (`publish-npm.yml` in `bigduu/Lotus`)
-2. **Bamboo** → publish crates, embedding that exact Lotus as the web frontend (`publish-crate.yml` in `bigduu/Bamboo-agent`)
-3. **Bodhi** → build & ship desktop assets consuming both (`release.yml` in `bigduu/Bodhi-AI`)
+1. **Bamboo** → publish crates while staging the selected exact frontend package (`publish-crate.yml` in `bigduu/Bamboo-agent`)
+2. **Bodhi** → build and publish desktop assets using the same frontend package/version plus the exact accepted Bamboo revision (`release.yml` in `bigduu/Bodhi-AI`)
 
-Between steps, the train **waits until the artifact is actually visible on crates.io / npm** before continuing (see `wait_for_crates_version` / `wait_for_npm_version` in `release-train.yml`). All versions and refs default to `.github/release-train.config.json` (`from_manifest`), and can be overridden when dispatched manually.
+Before either dispatch, the train validates the config schema, root gitlinks, live accepted Bamboo/Bodhi refs, the Lotus Next artifact-source pointer, package name/version, registry tarball SHA-1 and integrity. For Lotus Next it also verifies the canonical universal manifest, every resource size/hash, the combined resource digest, source revision, clean state, and entrypoint. A mismatch stops the train before any cross-repository dispatch; a later Lotus Next development commit does not invalidate already accepted immutable bytes.
 
-The train also supports **partial releases**: dispatch with `targets` (e.g. `bamboo,bodhi`) to release a subset — excluded repos are pinned to the last published versions recorded in the config, and a pre-flight check refuses to reuse an already-published version (pass `resume=true` to resume a partially completed train instead). After a successful run, the train writes the published versions back to the config, and the nightly bump additionally scans the registries for the month's highest published number — so the counter never collides with an ad-hoc release.
+The train supports **partial releases** with `targets=bamboo` or `targets=bodhi`. An excluded Bamboo leg stays pinned to the last published version recorded in config; collision checks reject reused downstream versions unless `resume=true` is explicitly used for the same partial train. Manual callers may override downstream release versions, but frontend selection resolves only to the committed Lotus Next artifact or the single fixed legacy rollback.
 
-The live refs, release versions, and options are maintained in
+The nightly job scans Bamboo, Bodhi, and the Lotus Next registry when choosing the next `YYYY.M.N` number, updates only downstream version fields, and never changes the committed frontend identity. The accepted source refs/revisions, downstream versions, and exact frontend bytes are maintained in
 [`.github/release-train.config.json`](./.github/release-train.config.json); the
-README intentionally does not copy a version snapshot that will go stale.
+README intentionally does not copy their values.
 
 Related workflows (under `.github/workflows/`):
 
 | Workflow | Purpose |
 |---|---|
-| `release-train.yml` | Coordinated release (full or partial via `targets`): Lotus → Bamboo → Bodhi |
-| `nightly-release.yml` | Daily nightly auto-bump (`YYYY.M.N`) at 04:00 UTC |
+| `release-policy.yml` | Tests policy semantics and round-trips both locked npm artifacts on relevant changes |
+| `release-train.yml` | Fail-closed release (full or partial via `targets`): locked frontend → Bamboo → Bodhi |
+| `nightly-release.yml` | Daily downstream-only auto-bump (`YYYY.M.N`) at 04:00 UTC |
 | `submodule-guard.yml` | Validates submodule pointers on pushes to and pull requests targeting `main` |
 
 > **Default policy** —— Normal releases go through Zenith's release train; per-repo standalone flows are for recovery or special cases only.
@@ -220,13 +220,13 @@ git push
 | Module | Repository |
 |---|---|
 | Bodhi AI — desktop product surface | https://github.com/bigduu/Bodhi-AI |
-| Lotus — React UI layer | https://github.com/bigduu/Lotus |
+| Lotus — frozen fixed-version legacy rollback | https://github.com/bigduu/Lotus |
 | Bamboo — Rust agent runtime | https://github.com/bigduu/Bamboo-agent |
 | Bodhi Server — optional hosted accounts, credentials, routing, billing/quota, and provider proxy | https://github.com/bigduu/bodhi-server |
 | Pavilion — website & docs | https://github.com/bigduu/Pavilion |
 | Jiandu — filesystem-backed Rust memory library + stdio MCP server | https://github.com/bigduu/Jiandu |
 | Nova — computer-use MCP server | https://github.com/bigduu/Nova |
-| Lotus Next — experimental parallel frontend track, not the current Bodhi default | https://github.com/bigduu/lotus-next |
+| Lotus Next — canonical responsive frontend and default release artifact | https://github.com/bigduu/lotus-next |
 | Magpie — IM connector for Bamboo | https://github.com/bigduu/Magpie |
 
 **Key docs**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,11 +9,11 @@ Zenith 是它的大本营：桌面产品、前端、Rust 运行时、可选托�
 电脑操作、IM 集成与文档，一次 `--recursive` clone 全到位。
 
 [![Submodule Guard](https://img.shields.io/github/actions/workflow/status/bigduu/Zenith/submodule-guard.yml?branch=main&label=submodule%20guard&logo=github)](https://github.com/bigduu/Zenith/actions/workflows/submodule-guard.yml)
-[![Release Train](https://img.shields.io/badge/release%20train-Lotus%20→%20Bamboo%20→%20Bodhi-1f6feb)](https://github.com/bigduu/Zenith/actions/workflows/release-train.yml)
+[![Release Train](https://img.shields.io/badge/release%20train-Lotus%20Next%20artifact%20→%20Bamboo%20→%20Bodhi-1f6feb)](https://github.com/bigduu/Zenith/actions/workflows/release-train.yml)
 [![Versioning](https://img.shields.io/badge/versioning-nightly%20YYYY.M.N-8a2be2)](https://github.com/bigduu/Zenith/actions/workflows/nightly-release.yml)
 [![English README](https://img.shields.io/badge/lang-English-blue)](./README.md)
 
-**[▶ 先看 Bodhi AI](https://github.com/bigduu/Bodhi-AI)** · [Lotus](https://github.com/bigduu/Lotus) · [Bamboo](https://github.com/bigduu/Bamboo-agent) · [Bodhi Server](https://github.com/bigduu/bodhi-server) · [Pavilion](https://github.com/bigduu/Pavilion) · [架构总览](https://github.com/bigduu/Pavilion/blob/main/articles/zenith-architecture-overview.md)
+**[▶ 先看 Bodhi AI](https://github.com/bigduu/Bodhi-AI)** · [Lotus Next](https://github.com/bigduu/lotus-next) · [Bamboo](https://github.com/bigduu/Bamboo-agent) · [Bodhi Server](https://github.com/bigduu/bodhi-server) · [Pavilion](https://github.com/bigduu/Pavilion) · [架构总览](https://github.com/bigduu/Pavilion/blob/main/articles/zenith-architecture-overview.md)
 
 </div>
 
@@ -27,7 +27,7 @@ Zenith 是它的大本营：桌面产品、前端、Rust 运行时、可选托�
 |---|---|
 | **整套系统的地图** | 一个仓库就能看清产品、UI、runtime、backend、文档如何分工与协作 |
 | **9 个 submodule 一键拉取** | `--recursive` 一次拉取产品栈与配套服务 |
-| **协调发布列车** | Lotus → Bamboo → Bodhi 按依赖顺序发布，版本号从一份配置统一驱动 |
+| **协调发布列车** | 一个已验证的 Lotus Next 制品按依赖顺序供给 Bamboo → Bodhi，由一份 fail-closed 配置统一驱动 |
 | **每日 Nightly 自动版本** | 按 `YYYY.M.N` 日历版本自动递增并触发发布 |
 | **指针守护** | CI 在 push 到 `main` 及目标为 `main` 的 PR 中校验 submodule 指针 |
 | **明确的“从哪开始”** | 无论你想看产品、写前端还是改 runtime，都有明确入口 |
@@ -43,37 +43,37 @@ graph TD
   Z["Zenith (this repo)<br/>submodule pointers + release train"]
 
   Z --> B["Bodhi AI<br/>desktop product surface (Tauri shell)"]
-  Z --> L["Lotus<br/>React + Vite UI layer"]
+  Z --> L["Lotus<br/>固定 legacy 回滚"]
   Z --> R["Bamboo<br/>local-first Rust agent runtime"]
   Z --> S["Bodhi Server<br/>可选托管服务"]
   Z --> P["Pavilion<br/>website & docs"]
   Z --> J["Jiandu<br/>Rust 记忆库 + stdio MCP"]
   Z --> N["Nova<br/>computer-use MCP server"]
-  Z --> LN["Lotus Next<br/>实验性前端路线"]
+  Z --> LN["Lotus Next<br/>权威响应式 UI"]
   Z --> M["Magpie<br/>IM connector for Bamboo"]
 
   B -. 启动 / 复用 / 健康检查 .-> R
-  R -. 打包构建提供内嵌前端 .-> L
-  L -->|HTTP API + 共享 /v2/stream WebSocket| R
-  L -. legacy SSE fallback .-> R
+  R -. 打包构建提供锁定前端 .-> LN
+  LN -->|HTTP API + 共享 /v2/stream WebSocket| R
+  L -. 仅显式回滚 .-> R
   R -. 配置后可选使用 /proxy/* .-> S
   P -. explains .-> B
 ```
 
-> **重要** —— Bodhi 负责原生桌面壳和 Bamboo sidecar 生命周期：启动或复用 `bamboo serve`，并等待健康检查通过。打包构建加载由 Bamboo 提供的 Lotus 界面；开发模式保持使用 Lotus Vite dev server，同时在旁运行 Bamboo。Lotus 用 HTTP 发请求，实时事件默认走共享 `/v2/stream` WebSocket；只有显式关闭 WebSocket 或首次建连失败时才回退到 legacy SSE。Bodhi Server 对本地运行不是必需依赖；配置使用时，它提供账号/认证、凭据存储、配额/计费、模型路由与 provider proxy。
+> **重要** —— Bodhi 负责原生桌面壳和 Bamboo sidecar 生命周期：启动或复用 `bamboo serve`，并等待健康检查通过。打包构建默认使用 Bamboo、Bodhi 与 Zenith 发布策略共同锁定的同一份 Lotus Next npm 制品；legacy Lotus 只保留一个固定版本的显式回滚入口。Lotus Next 通过 HTTP 发请求，实时事件走共享 `/v2/stream` WebSocket。Bodhi Server 对本地运行不是必需依赖；配置使用时，它提供账号/认证、凭据存储、配额/计费、模型路由与 provider proxy。
 
 ### 各模块职责
 
 | 模块 | 路径 | 角色 | 从哪开始 |
 |---|---|---|---|
 | **Bodhi AI** | `bodhi/` | 对外产品门面：Tauri 桌面壳、原生集成、打包发布与受管 Bamboo sidecar 生命周期 | [Bodhi AI](https://github.com/bigduu/Bodhi-AI) |
-| **Lotus** | `lotus/` | UI 交互层：React + Vite、HTTP 请求、共享 WebSocket 实时事件、legacy SSE fallback、界面状态与设置 | [Lotus](https://github.com/bigduu/Lotus) |
-| **Bamboo** | `bamboo/` | 执行引擎与生产 Lotus host：本地优先 Rust runtime，提供 HTTP、WebSocket 与 legacy SSE API | [Bamboo Agent](https://github.com/bigduu/Bamboo-agent) |
+| **Lotus** | `lotus/` | 已冻结的 legacy React + Vite UI；迁移验收与退役门禁完成前，仅作为固定回滚包保留 | [Lotus](https://github.com/bigduu/Lotus) |
+| **Bamboo** | `bamboo/` | 执行引擎与生产 Lotus Next host：本地优先 Rust runtime，提供 HTTP、WebSocket 与 legacy SSE API | [Bamboo Agent](https://github.com/bigduu/Bamboo-agent) |
 | **Bodhi Server** | `bodhi-server/` | 可选托管 Go 服务：账号/认证、API key、加密 provider 凭据、模型路由、配额/计费与 provider proxy | [Bodhi Server](https://github.com/bigduu/bodhi-server) |
 | **Pavilion** | `pavilion/` | 官网与文档：下载入口、文档中心与对外叙事 | [Pavilion](https://github.com/bigduu/Pavilion) |
 | **Jiandu** | `jiandu/` | 权威共享记忆：独立文件系统 Rust store、无 embedding 的词法检索、宿主生成的 Dream 快照持久化，以及单 `memory` tool 的 stdio MCP | [Jiandu](https://github.com/bigduu/Jiandu) · [agent 使用指南](./AGENTS.md#shared-memory-via-jiandu-mcp) · [便携 Skill](https://github.com/bigduu/Jiandu/blob/v0.2.0/skills/jiandu-memory/SKILL.md) |
 | **Nova** | `nova/` | 电脑操作：通过 MCP 暴露原生桌面交互能力 | [Nova](https://github.com/bigduu/Nova) |
-| **Lotus Next** | `lotus-next/` | 实验性并行界面：响应式 React + Vite 重构，当前不声明功能等价或生产就绪 | [Lotus Next](https://github.com/bigduu/lotus-next) |
+| **Lotus Next** | `lotus-next/` | 权威响应式 React + Vite UI，也是 Bamboo 与 Bodhi 发布默认消费的前端制品 | [Lotus Next](https://github.com/bigduu/lotus-next) |
 | **Magpie** | `magpie/` | IM 集成：独立连接器与 Bamboo service plugin | [Magpie](https://github.com/bigduu/Magpie) |
 | **Zenith (root)** | `.` | 协调仓库：submodule 指针、根级文档、release train | 你在这里 |
 
@@ -92,56 +92,56 @@ Zenith 最大的价值，是让任何一个人都能快速找到正确的入口�
 
 **如果你想参与开发**
 - 桌面产品 / Tauri 壳 → `bodhi/`
-- 前端交互 / React UI → `lotus/`
+- 权威前端交互 / React UI → `lotus-next/`
+- 固定 legacy 回滚 → `lotus/`
 - Agent runtime / Rust 后端 → `bamboo/`
 - 可选托管账号 / 凭据 / 路由 / 计费服务 → `bodhi-server/`
 - 官网 / 文档 / 对外内容 → `pavilion/`
 - 共享记忆 MCP → `jiandu/`
 - 电脑操作 MCP → `nova/`
-- 实验性下一代界面 → `lotus-next/`
 - IM 连接器 / Bamboo service plugin → `magpie/`
 
 ### 2. 这套栈为什么这样分
 
 核心产品链路按层拆分，让每一层都能独立演进，又能在发布时收敛成一个产品：
 
-- **界面与体验** 放在 Lotus（React/Vite）；请求走 HTTP，实时事件默认复用一条共享 WebSocket，并保留 legacy SSE fallback。
+- **界面与体验** 放在 Lotus Next（React/Vite）；请求走 HTTP，实时事件复用一条共享 WebSocket。
 - **执行逻辑与生产界面托管** 放在 Bamboo（Rust），本地优先、可单独运行。
 - **可选托管账号、凭据、模型路由、配额/计费与 provider proxy** 在配置使用时由 Bodhi Server（Go）提供；本地 Bodhi + Bamboo 链路不依赖它。
-- **桌面壳** 放在 Bodhi：负责原生集成、打包发布与受管 Bamboo sidecar 生命周期；release 构建中的 Lotus 由 Bamboo 提供。
+- **桌面壳** 放在 Bodhi：负责原生集成、打包发布与受管 Bamboo sidecar 生命周期；release 构建与 Bamboo 消费同一份精确锁定的 Lotus Next 制品。
 - **对外叙事** 放在 Pavilion，与代码解耦。
 
-另外四个 submodule 保持独立边界：Jiandu 拥有唯一权威的文件系统记忆根、
+另外三个 submodule 保持独立边界：Jiandu 拥有唯一权威的文件系统记忆根、
 确定性的无 embedding 词法检索、宿主生成的 Dream 快照字节，以及单工具
 stdio MCP server。宿主负责选择 query terms、可选 rerank、prompt 位置与预算，
 以及 Dream 的生成和节奏；可选便携 Skill 只教授这份契约，并由宿主显式启用。
-Nova 通过 MCP 提供电脑操作；Lotus Next 是与 Lotus 并行的实验性前端路线，
-并非当前 Bodhi 默认界面；Magpie 负责把 IM 平台连接到 Bamboo。
+Nova 通过 MCP 提供电脑操作；Magpie 负责把 IM 平台连接到 Bamboo。legacy
+Lotus 在剩余迁移验收与退役门禁完成前，继续作为有界的固定回滚保留。
 
 ### 3. 协调发布列车
 
-多个仓库要同时升级版本、按依赖顺序发布，很容易出错。Zenith 用一份配置 + 一条 workflow 把它变成一次点击。
+多个仓库要按依赖顺序发布，很容易出错。Zenith 用一份经过 review 的权威配置 + 一条 workflow 把它收敛起来。
 
-发布顺序由依赖关系固定为：
+Lotus Next 的发布是独立、受保护的 producer 步骤；只有源码审核、制品发布和下游 lock 刷新完成后，release train 才消费它，并且不会在列车里重新发布或改写前端。下游顺序固定为：
 
-1. **Lotus** → 发布 npm 包 `@bigduu/lotus`（`bigduu/Lotus` 的 `publish-npm.yml`）
-2. **Bamboo** → 发布 crate，并把当天这个 Lotus 嵌入为 web 前端（`bigduu/Bamboo-agent` 的 `publish-crate.yml`）
-3. **Bodhi** → 构建并发布桌面产物，消费前两者（`bigduu/Bodhi-AI` 的 `release.yml`）
+1. **Bamboo** → 发布 crate，并暂存所选的精确前端包（`bigduu/Bamboo-agent` 的 `publish-crate.yml`）
+2. **Bodhi** → 用同一个前端 package/version 和被接受的精确 Bamboo revision 构建并发布桌面产物（`bigduu/Bodhi-AI` 的 `release.yml`）
 
-每一步之间，release train 会**等待制品在 crates.io / npm 上真正可见**后再进入下一步（见 `release-train.yml` 中的 `wait_for_crates_version` / `wait_for_npm_version`）。所有版本与 ref 默认从 `.github/release-train.config.json` 读取（`from_manifest`），也可在手动触发时覆盖。
+任何跨仓库 dispatch 之前，列车都会验证配置 schema、根 gitlink、当前被接受的 Bamboo/Bodhi ref、Lotus Next 制品源码指针、package name/version、registry tarball SHA-1 与 integrity。选择 Lotus Next 时，还会逐项验证 canonical universal manifest、所有资源的 size/hash、合并资源摘要、源码 revision、clean 状态与 entrypoint；任一不一致都会提前停止，而 Lotus Next 后续开发提交不会让已经验收的不可变制品失效。
 
-列车也支持**部分发车**：手动触发时传 `targets`（如 `bamboo,bodhi`）只发布子集——未选中的仓库固定使用配置中记录的最近已发布版本；预检会拒绝复用已发布过的版本号（重跑半途失败的列车请传 `resume=true`）。列车成功后会把实际发布的版本写回配置，nightly 定版时还会扫描 registry 取当月最大序号，保证计数器不会与临时发布撞号。
+列车支持 `targets=bamboo` 或 `targets=bodhi` 的**部分发车**。Bamboo 未入列时固定使用配置里记录的最近已发布版本；碰撞检查拒绝复用下游版本，只有对同一趟半途失败列车显式传 `resume=true` 才会跳过已经存在的制品。手动调用者可以覆盖下游版本，但前端只能解析为已提交的 Lotus Next 制品，或唯一固定的 legacy rollback。
 
-当前使用的 ref、发布版本与选项统一维护在
+nightly 在生成下一个 `YYYY.M.N` 时扫描 Bamboo、Bodhi 与 Lotus Next registry，只更新下游版本字段，永远不改写已提交的前端身份。被接受的源码 ref/revision、下游版本以及精确前端字节统一维护在
 [`.github/release-train.config.json`](./.github/release-train.config.json)；
-README 不再复制一份会过期的版本快照。
+README 不复制会过期的具体值。
 
 相关 workflow (位于 `.github/workflows/`):
 
 | Workflow | 作用 |
 |---|---|
-| `release-train.yml` | 协调发布（全量或用 `targets` 部分发车）：Lotus → Bamboo → Bodhi |
-| `nightly-release.yml` | 每天 UTC 04:00（北京时间 12:00）按 `YYYY.M.N` 自动递增版本并触发 |
+| `release-policy.yml` | 在相关变更上测试策略语义，并从公共 registry 重验两份锁定 npm 制品 |
+| `release-train.yml` | fail-closed 发布（全量或用 `targets` 部分发车）：锁定前端 → Bamboo → Bodhi |
+| `nightly-release.yml` | 每天 UTC 04:00（北京时间 12:00）仅递增下游 `YYYY.M.N` 并触发 |
 | `submodule-guard.yml` | 在 push 到 `main` 及目标为 `main` 的 PR 中校验 submodule 指针 |
 
 > **默认策略** —— 正常发布走 Zenith 的 release train；子仓库的独立发布流程仅用于恢复或特殊情况。
@@ -218,13 +218,13 @@ git push
 | 模块 | Repository |
 |---|---|
 | Bodhi AI — 桌面产品门面 | https://github.com/bigduu/Bodhi-AI |
-| Lotus — React UI 层 | https://github.com/bigduu/Lotus |
+| Lotus — 已冻结的固定版本 legacy 回滚 | https://github.com/bigduu/Lotus |
 | Bamboo — Rust agent runtime | https://github.com/bigduu/Bamboo-agent |
 | Bodhi Server — 可选托管账号、凭据、路由、配额/计费与 provider proxy | https://github.com/bigduu/bodhi-server |
 | Pavilion — 官网与文档 | https://github.com/bigduu/Pavilion |
 | Jiandu — 文件系统持久化 Rust 记忆库 + stdio MCP server | https://github.com/bigduu/Jiandu |
 | Nova — 电脑操作 MCP 服务 | https://github.com/bigduu/Nova |
-| Lotus Next — 实验性并行前端路线，并非当前 Bodhi 默认界面 | https://github.com/bigduu/lotus-next |
+| Lotus Next — 权威响应式前端与默认发布制品 | https://github.com/bigduu/lotus-next |
 | Magpie — Bamboo 的 IM 连接器 | https://github.com/bigduu/Magpie |
 
 **关键文档**

--- a/docs/lotus-next-migration.md
+++ b/docs/lotus-next-migration.md
@@ -1,6 +1,8 @@
-# Lotus → Lotus-Next 迁移体检与落地计划
+# Lotus → Lotus Next 迁移体检与落地计划
 
-> 状态:**功能补齐大批次已落地** · 最后更新:2026-07-07
+> 状态:**生产默认消费与锁定发布链已落地；运行验收与 legacy 退役仍在推进** · 最后更新:2026-09-13
+>
+> **2026-09-13 生产/发布里程碑:**`@bigduu/lotus-next@2026.9.14` 已由受保护源码提交发布；Bamboo 和 Bodhi 已锁定并默认消费同一份 universal artifact；Zenith 已固定对应源码指针。根 release train 不再生产 legacy Lotus，也不自动发布 Lotus Next，而是在任何跨仓库 dispatch 前校验被接受的源码 ref、根 gitlink、npm tarball SHA-1/integrity，以及 Lotus Next manifest 中每个资源的 size/hash。legacy `@bigduu/lotus@2026.8.28` 仅保留为显式固定回滚。本阶段没有实际触发新的 Bamboo/Bodhi release。
 >
 > **2026-07-07 大批次(用户拍板:除 i18n 全部同步;传输只要 WSS 不要 SSE):**
 > 1. **传输 WSS-only 完成**:删除两条 legacy SSE 路径 + WS→SSE 回退机制 + `bodhi_api_v2_ws` 开关(净 −541 行);v2Stream 即唯一传输,初连失败与断线同走有界退避重连;msgpack 保持 opt-in。§2.2 的 "v2 WebSocket 传输 🟡" 行已过时 → ✅ 且比 lotus 更进一步(lotus 还保留回退)。
@@ -8,13 +10,13 @@
 > 3. **流式韧性完成**:被动观察引擎(他端/定时任务驱动的 run 自动订阅)、搁浅终态回收、visibilitychange 回收、WS 重连即时 reconcile(WSS-only 后这些是必需品,不再有 SSE 兜底)。
 > 4. **Settings 深度(9 路并行实现)**:定时任务全触发类型+策略+run-now+历史(修复 P0:cron 字段 `expression`→`expr`,创建从未生效)、Providers 深度(enabled 开关/类型变更/defaults.*/overrides/OAuth 打磨)、MCP 深度(编辑/env/cwd/headers/工具列表)、技能启停+搜索、通知后端偏好、系统面板(代理/记忆/子代理/工具/访问密码/模型限额/会话维护)、集群 tab + MachineTag(#33/#34 数据层已逐字移植)、指标仪表盘(纯 SVG)、提示词 + 工作流 tab + CommandService、导出 PDF 改渲染管线(CJK 安全)。
 > 5. **聊天集成**:enhance_prompt 管线恢复(此前静默缺失)、新会话系统提示词预设 chip、SlashMenu 合并工作流(/v1/commands + 发送展开)、键盘导航(↑↓/Enter/Tab/Esc)、每会话草稿、待答问题会话打开恢复、AI 生成标题、主题跟随系统、Root 启动顺序修复(密码门先于 setup 探测)+ 有界重试、preloadError 自动重载、根 ErrorBoundary。
-> **仍未做**:FileChangeViewer/Diffs 区、HomeDashboard + 模板启动器、单 pane 多会话并发流式(useChat per-session buffer Map)、侧栏过滤/内容搜索/批量删除、命令面板深度、mermaid 缩放/主题、消息上下文操作、输入历史、Run Project Dream、引导 tour、传输测试套件;生产切换(选项 B)仍按 dev-first 分期推迟。
+> **仍未做**:FileChangeViewer/Diffs 区、HomeDashboard + 模板启动器、单 pane 多会话并发流式(useChat per-session buffer Map)、侧栏过滤/内容搜索/批量删除、命令面板深度、mermaid 缩放/主题、消息上下文操作、输入历史、Run Project Dream、引导 tour、传输测试套件；以及迁移 tracker 中的本地/远程响应式验收、两次启动 Jiandu 连续性、legacy 工作对账、回滚窗口移除与仓库归档。
 >
 > **已拍板的方向决策:**
 > 1. **产品定位 = next 渐进取代 lotus**(最终走选项 B:打包脚本改服 lotus-next;lotus 在 next 达到功能水位后退役)。
 > 2. **优先抽取 `@bigduu/lotus-core` 共享层**(两端共享后端/服务/状态层)。
 >
-> **修订后的分期(2026-06-28):先不并入 bamboo。** 当前阶段 = **dev-first**:bamboo 继续只服务 lotus(embed 管线一行不改),next 用 vite dev(`:9563` proxy → `:9562`)迭代开发,等功能达到水位后再做选项 B 的生产切换。选项 B / `--static-dir` 部署 = 已验证可行但**推迟**。
+> **历史分期(2026-06-28，已被 2026-09-13 里程碑取代):先不并入 bamboo。** 当时采用 **dev-first**：bamboo 继续只服务 lotus，next 用 vite dev(`:9563` proxy → `:9562`)迭代；该生产切换现已通过受保护 Bamboo/Bodhi consumer 变更完成。
 >
 > **终局定调(2026-06-28):next = 桌面+移动统一的单一 UI,antd 整体退役。** 真正驱动力是 antd 定制化能力低(改 UI 处处受制),不只是移动。所以 next 要长成**响应式**(窄屏单栏 ↔ 宽屏多栏)以最终接管桌面,lotus 退役。**当前最高杠杆 = 补 next 的组件地基**(见 §9),否则 next 会从"antd 改不动"换成"内联 Tailwind 散落、改 10 处"的新泥潭。i18n 暂缓(工作量大、非核心)。
 
@@ -176,24 +178,26 @@ next 已 browser-first(`isTauriEnvironment` 全守卫,tauri plugin 懒加载,HTT
 
 ---
 
-## 7. 发布链路缺口清单(lotus-next 当一等公民)
+## 7. 发布链路现状(Lotus Next 已是一等制品)
 
-1. `release-train.config.json` + `nightly-release.yml` 的 jq 加 `versions.lotus_next`(package.json 留 `0.0.0`,发布时打日期版本)。
-2. 建 publish workflow(镜像 lotus 的 `publish-npm.yml` 发 `@bigduu/lotus-next`)**或**走静态 artifact。
-3. `release-train.yml` 加 dispatch + wait 步骤。
-4. 按选项 B 接 bamboo 打包(改 `frontend-package.cjs` 消费 `@bigduu/lotus-next` + `frontend_name`,bodhi `release.yml` 传 `lotus_next_version`)。
-5. submodule 指针机制已被 `submodule-guard.yml` 覆盖(next 已在 `.gitmodules`);推 zenith main 注意 nightly auto-commit 冲突,fetch + rebase 即可。
+1. **Producer 独立:**Lotus Next 的 `publish-npm.yml` 从 clean 默认分支构建、跑 Node/浏览器/真实 Bamboo 验证，再发布精确 npm 版本；根 release train 不重复这一 producer。
+2. **Consumer 一致:**Bamboo 与 Bodhi 的 committed lock 对 package/version、source revision、entrypoint、manifest SHA-256 与 resource digest 完全一致，且默认都选择 Lotus Next。
+3. **根权威:**`release-train.config.json` 同时固定被接受的 Bamboo/Bodhi workflow ref + revision、Lotus Next 源码/gitlink 关系、完整 manifest 身份、npm shasum/integrity，以及唯一 legacy rollback。
+4. **Fail closed:**`release-train.yml` 默认只跑 Bamboo → Bodhi。它先从公共 registry 下载所选精确 tarball 并逐字节验证，再检查 Bamboo/Bodhi 的 live accepted ref、所有相关 root pointer 与 Next manifest source；没有 `latest`、skip-tests、legacy producer 或自动 Next publication。Next 后续开发提交不会让已验收制品失效。
+5. **Nightly 下游化:**`nightly-release.yml` 扫描 Lotus Next、Bamboo 与 Bodhi 已占用的 `YYYY.M.N`，但只更新/release Bamboo 与 Bodhi 版本，绝不改写 frontend identity。
+6. **仍待验收:**实际运行一趟受控下游 release、完成本地/远程响应式和两次启动 Jiandu 证据后，才能移除 rollback、对账遗留工作并归档 legacy Lotus。
 
 ---
 
-## 8. 分阶段迁移路线(总,2026-06-28 修订:dev-first)
+## 8. 分阶段迁移路线(2026-09-13 修订)
 
-> 修订要点:**不急着并入 bamboo**。当前停留在 dev 开发,把功能做齐 + 共享层去重,部署切换后移。
+> 当前阶段已从 dev-first 进入**生产默认消费后的验收/退役窗口**。默认包与 release authority 已切到 Lotus Next，但 legacy 删除仍必须等待真实运行证据。
 
-- **当前阶段 = dev-first 开发**:bamboo 只服务 lotus(不动);next 用 vite dev(`:9563` proxy → `:9562`)迭代。手机调试走局域网(`host:true` 已开,`http://<Mac-LAN-IP>:9563`)或为 :9563 单开一条 tunnel。
+- **已完成 — producer/consumer/根指针/发布策略:**Lotus Next artifact、Bamboo、Bodhi 与 Zenith 的受保护交付链已对齐；默认发布消费 Next，legacy 只能显式回滚。
+- **当前阶段 — 真实验收:**分别收集本地与远程宽/窄屏关键路径、桌面壳启动、两次启动 Jiandu 连续性和受控 release 证据；失败车道独立记录，不以绿色 CI 替代行为验收。
 - **P1 去重固本(可立即并行)**:抽 `@bigduu/lotus-core`,统一 4 个漂移,搬测试进 core;清掉第 3 节死代码(死代码已于 2026-06-28 清理:openAiStreamingRunner / compat/ / dist.lotus-bak)。dev 模式下双份同步痛持续,此项价值不降反升。
 - **P2 功能补全**(按移动价值排序):i18n UI 多语 + 切换器(最大退化)→ 远程 Setup 流 → System Prompt / Workflows / Plan 按需 → 主题跟随系统 → Provider 多实例深度核对。
-- **P3 部署切换(达到功能水位后再做)**:选项 B 正式让 bamboo/bodhi 服务 next;接 CI/release(第 7 节)。**已验证**:`bamboo serve --static-dir lotus-next/dist` 可作为生产 SPA+API 单 origin 服务(6 项 curl 验证通过),随时可切。
+- **P3 部署与发布切换(已完成默认路径)**:Bamboo/Bodhi 已默认消费锁定的 `@bigduu/lotus-next`；Zenith release train 已接管精确制品验证与 Bamboo → Bodhi 编排。真实 release 与最终 rollback 删除仍是独立门禁。
 - **P4 容器化**:新 mobile Tauri 壳,连远程 bamboo。
 
 > **P0 临时点亮(已验证、暂不启用)**:`bamboo serve --port 9562 --bind 127.0.0.1 --data-dir ~/.bamboo --static-dir <lotus-next/dist>` + 现有 :9562 tunnel,即可让手机看到带真实 provider/会话的 lotus-next。需先停 bodhi/常规 :9562;回退 = 杀进程重启 bodhi。按修订分期暂缓。

--- a/scripts/release-train-policy.cjs
+++ b/scripts/release-train-policy.cjs
@@ -1,0 +1,853 @@
+#!/usr/bin/env node
+"use strict"
+
+const { createHash } = require("node:crypto")
+const {
+  appendFileSync,
+  lstatSync,
+  readFileSync,
+  readdirSync,
+} = require("node:fs")
+const path = require("node:path")
+
+const CONFIG_SCHEMA_VERSION = 2
+const MANIFEST_FILE = "lotus-next-manifest.json"
+const LOTUS_NEXT_PACKAGE = "@bigduu/lotus-next"
+const LEGACY_LOTUS_PACKAGE = "@bigduu/lotus"
+
+const strictSemver =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/
+const sha1Pattern = /^[0-9a-f]{40}$/
+const sha256Pattern = /^[0-9a-f]{64}$/
+const revisionPattern = /^[0-9a-f]{40}$/
+const repositoryPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/
+const workflowPattern = /^[A-Za-z0-9][A-Za-z0-9._-]*\.ya?ml$/
+const outputKeyPattern = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+const isPlainObject = (value) =>
+  typeof value === "object" &&
+  value !== null &&
+  !Array.isArray(value) &&
+  Object.getPrototypeOf(value) === Object.prototype
+
+const assertPlainObject = (value, label) => {
+  if (!isPlainObject(value)) {
+    throw new Error(label + " must be an object.")
+  }
+  return value
+}
+
+const assertExactKeys = (value, expectedKeys, label) => {
+  assertPlainObject(value, label)
+  const actual = Object.keys(value).sort()
+  const expected = [...expectedKeys].sort()
+  if (
+    actual.length !== expected.length ||
+    actual.some((key, index) => key !== expected[index])
+  ) {
+    throw new Error(label + " must contain exactly: " + expectedKeys.join(", ") + ".")
+  }
+}
+
+const assertString = (value, label) => {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(label + " must be a non-empty string.")
+  }
+  if (/[\u0000-\u001f\u007f-\u009f]/u.test(value)) {
+    throw new Error(label + " must not contain control characters.")
+  }
+  return value
+}
+
+const assertSemver = (value, label) => {
+  assertString(value, label)
+  if (!strictSemver.test(value) || value === "0.0.0") {
+    throw new Error(label + " must be an exact, non-placeholder SemVer.")
+  }
+  return value
+}
+
+const assertRevision = (value, label) => {
+  if (typeof value !== "string" || !revisionPattern.test(value)) {
+    throw new Error(label + " must be a lowercase 40-character Git object ID.")
+  }
+  return value
+}
+
+const assertDigest = (value, pattern, label) => {
+  if (typeof value !== "string" || !pattern.test(value)) {
+    throw new Error(label + " has an invalid digest.")
+  }
+  return value
+}
+
+const assertNpmIntegrity = (value, label) => {
+  assertString(value, label)
+  if (!value.startsWith("sha512-")) {
+    throw new Error(label + " must use sha512.")
+  }
+  const encoded = value.slice("sha512-".length)
+  const decoded = Buffer.from(encoded, "base64")
+  if (decoded.length !== 64 || decoded.toString("base64") !== encoded) {
+    throw new Error(label + " is not a canonical SHA-512 integrity value.")
+  }
+  return value
+}
+
+const assertRef = (value, label) => {
+  assertString(value, label)
+  const segments = value.split("/")
+  if (
+    !/^[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(value) ||
+    value.includes("..") ||
+    value.includes("//") ||
+    value.includes("@{") ||
+    value.endsWith("/") ||
+    value.endsWith(".") ||
+    segments.some(
+      (segment) =>
+        segment.length === 0 ||
+        segment === "." ||
+        segment === ".." ||
+        segment.endsWith(".lock"),
+    )
+  ) {
+    throw new Error(label + " is not a safe branch ref.")
+  }
+  return value
+}
+
+const validateSource = (source, name, expected) => {
+  const label = "sources." + name
+  assertExactKeys(
+    source,
+    ["repository", "workflow", "ref", "revision", "rootPath"],
+    label,
+  )
+  if (
+    !repositoryPattern.test(assertString(source.repository, label + ".repository")) ||
+    source.repository !== expected.repository
+  ) {
+    throw new Error(label + ".repository must be exactly " + expected.repository + ".")
+  }
+  if (
+    !workflowPattern.test(assertString(source.workflow, label + ".workflow")) ||
+    source.workflow !== expected.workflow
+  ) {
+    throw new Error(label + ".workflow must be exactly " + expected.workflow + ".")
+  }
+  assertRef(source.ref, label + ".ref")
+  assertRevision(source.revision, label + ".revision")
+  if (source.rootPath !== expected.rootPath) {
+    throw new Error(label + ".rootPath must be exactly " + expected.rootPath + ".")
+  }
+}
+
+const validateLotusNext = (frontend) => {
+  const label = "frontend.lotusNext"
+  assertExactKeys(
+    frontend,
+    [
+      "repository",
+      "ref",
+      "rootPath",
+      "manifestSchemaVersion",
+      "packageName",
+      "packageVersion",
+      "sourceRevision",
+      "sourceDirty",
+      "entrypoint",
+      "resourcesSha256",
+      "manifestSha256",
+      "npmShasum",
+      "npmIntegrity",
+    ],
+    label,
+  )
+  if (frontend.repository !== "bigduu/lotus-next") {
+    throw new Error(label + ".repository must be exactly bigduu/lotus-next.")
+  }
+  assertRef(frontend.ref, label + ".ref")
+  if (frontend.rootPath !== "lotus-next") {
+    throw new Error(label + ".rootPath must be exactly lotus-next.")
+  }
+  if (frontend.manifestSchemaVersion !== 1) {
+    throw new Error(label + ".manifestSchemaVersion must be exactly 1.")
+  }
+  if (frontend.packageName !== LOTUS_NEXT_PACKAGE) {
+    throw new Error(label + ".packageName must be exactly " + LOTUS_NEXT_PACKAGE + ".")
+  }
+  assertSemver(frontend.packageVersion, label + ".packageVersion")
+  assertRevision(frontend.sourceRevision, label + ".sourceRevision")
+  if (frontend.sourceDirty !== false) {
+    throw new Error(label + ".sourceDirty must be exactly false.")
+  }
+  if (frontend.entrypoint !== "index.html") {
+    throw new Error(label + ".entrypoint must be exactly index.html.")
+  }
+  assertDigest(frontend.resourcesSha256, sha256Pattern, label + ".resourcesSha256")
+  assertDigest(frontend.manifestSha256, sha256Pattern, label + ".manifestSha256")
+  assertDigest(frontend.npmShasum, sha1Pattern, label + ".npmShasum")
+  assertNpmIntegrity(frontend.npmIntegrity, label + ".npmIntegrity")
+}
+
+const validateLegacyRollback = (frontend) => {
+  const label = "frontend.legacyRollback"
+  assertExactKeys(
+    frontend,
+    ["packageName", "packageVersion", "npmShasum", "npmIntegrity"],
+    label,
+  )
+  if (frontend.packageName !== LEGACY_LOTUS_PACKAGE) {
+    throw new Error(
+      label + ".packageName must be exactly " + LEGACY_LOTUS_PACKAGE + ".",
+    )
+  }
+  assertSemver(frontend.packageVersion, label + ".packageVersion")
+  assertDigest(frontend.npmShasum, sha1Pattern, label + ".npmShasum")
+  assertNpmIntegrity(frontend.npmIntegrity, label + ".npmIntegrity")
+}
+
+const validateConfig = (config) => {
+  assertExactKeys(
+    config,
+    ["schemaVersion", "sources", "versions", "frontend"],
+    "release-train config",
+  )
+  if (config.schemaVersion !== CONFIG_SCHEMA_VERSION) {
+    throw new Error(
+      "release-train config schemaVersion must be exactly " +
+        CONFIG_SCHEMA_VERSION +
+        ".",
+    )
+  }
+
+  assertExactKeys(config.sources, ["bamboo", "bodhi"], "sources")
+  validateSource(config.sources.bamboo, "bamboo", {
+    repository: "bigduu/Bamboo-agent",
+    workflow: "publish-crate.yml",
+    rootPath: "bamboo",
+  })
+  validateSource(config.sources.bodhi, "bodhi", {
+    repository: "bigduu/Bodhi-AI",
+    workflow: "release.yml",
+    rootPath: "bodhi",
+  })
+
+  assertExactKeys(config.versions, ["release", "bamboo", "bodhi"], "versions")
+  assertSemver(config.versions.release, "versions.release")
+  assertSemver(config.versions.bamboo, "versions.bamboo")
+  assertSemver(config.versions.bodhi, "versions.bodhi")
+
+  assertExactKeys(
+    config.frontend,
+    ["defaultPackage", "lotusNext", "legacyRollback"],
+    "frontend",
+  )
+  if (config.frontend.defaultPackage !== LOTUS_NEXT_PACKAGE) {
+    throw new Error(
+      "frontend.defaultPackage must be exactly " + LOTUS_NEXT_PACKAGE + ".",
+    )
+  }
+  validateLotusNext(config.frontend.lotusNext)
+  validateLegacyRollback(config.frontend.legacyRollback)
+  return config
+}
+
+const readConfig = (configPath) => {
+  const absolutePath = path.resolve(configPath)
+  const metadata = lstatSync(absolutePath)
+  if (metadata.isSymbolicLink() || !metadata.isFile()) {
+    throw new Error("Release-train config must be a regular file.")
+  }
+  const source = readFileSync(absolutePath, "utf8")
+  let config
+  try {
+    config = JSON.parse(source)
+  } catch (error) {
+    throw new Error(
+      "Release-train config is not valid JSON: " +
+        (error instanceof Error ? error.message : String(error)),
+    )
+  }
+  validateConfig(config)
+  if (source !== JSON.stringify(config, null, 2) + "\n") {
+    throw new Error("Release-train config must use canonical two-space JSON.")
+  }
+  return config
+}
+
+const parseBoolean = (value, label, fallback) => {
+  if (value === undefined || value === "") return fallback
+  if (value === true || value === "true") return true
+  if (value === false || value === "false") return false
+  throw new Error(label + " must be exactly true or false.")
+}
+
+const parseTargets = (value) => {
+  const raw = value === undefined || value.trim() === "" ? "bamboo,bodhi" : value
+  const targets = raw.split(",").map((target) => target.trim())
+  if (targets.some((target) => target.length === 0)) {
+    throw new Error("targets must not contain an empty entry.")
+  }
+  if (new Set(targets).size !== targets.length) {
+    throw new Error("targets must not contain duplicates.")
+  }
+  for (const target of targets) {
+    if (target !== "bamboo" && target !== "bodhi") {
+      throw new Error(
+        "Unknown release target " +
+          JSON.stringify(target) +
+          " (expected bamboo and/or bodhi).",
+      )
+    }
+  }
+  return new Set(targets)
+}
+
+const resolveVersion = (input, fallback, label) => {
+  const value =
+    input === undefined || input === "" || input === "from_manifest"
+      ? fallback
+      : input
+  return assertSemver(value, label)
+}
+
+const selectFrontend = (config, packageName) => {
+  if (packageName === config.frontend.lotusNext.packageName) {
+    return { selection: "lotus-next", identity: config.frontend.lotusNext }
+  }
+  if (packageName === config.frontend.legacyRollback.packageName) {
+    return { selection: "legacy-rollback", identity: config.frontend.legacyRollback }
+  }
+  throw new Error(
+    "frontend_package must be exactly " +
+      config.frontend.lotusNext.packageName +
+      " or " +
+      config.frontend.legacyRollback.packageName +
+      ".",
+  )
+}
+
+const resolvePolicy = (config, input = {}) => {
+  validateConfig(config)
+  const targets = parseTargets(input.targets)
+  const includeBamboo = targets.has("bamboo")
+  const includeBodhi = targets.has("bodhi")
+  const resume = parseBoolean(input.resume, "resume", false)
+  const releaseVersion = resolveVersion(
+    input.releaseVersion,
+    config.versions.release,
+    "release_version",
+  )
+  const bambooVersion = resolveVersion(
+    input.bambooVersion,
+    includeBamboo ? releaseVersion : config.versions.bamboo,
+    "bamboo_version",
+  )
+  const bodhiVersion = resolveVersion(
+    input.bodhiVersion,
+    includeBodhi ? releaseVersion : config.versions.bodhi,
+    "bodhi_version",
+  )
+  const requestedFrontend =
+    input.frontendPackage === undefined ||
+    input.frontendPackage === "" ||
+    input.frontendPackage === "from_manifest"
+      ? config.frontend.defaultPackage
+      : input.frontendPackage
+  const frontend = selectFrontend(config, requestedFrontend)
+
+  return {
+    include_bamboo: String(includeBamboo),
+    include_bodhi: String(includeBodhi),
+    resume: String(resume),
+    release_version: releaseVersion,
+    bamboo_version: bambooVersion,
+    bodhi_version: bodhiVersion,
+    bamboo_repository: config.sources.bamboo.repository,
+    bamboo_workflow: config.sources.bamboo.workflow,
+    bamboo_ref: config.sources.bamboo.ref,
+    bamboo_revision: config.sources.bamboo.revision,
+    bamboo_root_path: config.sources.bamboo.rootPath,
+    bodhi_repository: config.sources.bodhi.repository,
+    bodhi_workflow: config.sources.bodhi.workflow,
+    bodhi_ref: config.sources.bodhi.ref,
+    bodhi_revision: config.sources.bodhi.revision,
+    bodhi_root_path: config.sources.bodhi.rootPath,
+    lotus_next_repository: config.frontend.lotusNext.repository,
+    lotus_next_ref: config.frontend.lotusNext.ref,
+    lotus_next_revision: config.frontend.lotusNext.sourceRevision,
+    lotus_next_root_path: config.frontend.lotusNext.rootPath,
+    frontend_selection: frontend.selection,
+    frontend_package: frontend.identity.packageName,
+    frontend_version: frontend.identity.packageVersion,
+  }
+}
+
+const formatGitHubOutputs = (outputs) => {
+  assertPlainObject(outputs, "GitHub outputs")
+  let result = ""
+  for (const [key, rawValue] of Object.entries(outputs)) {
+    if (!outputKeyPattern.test(key)) {
+      throw new Error("Unsafe GitHub output key " + JSON.stringify(key) + ".")
+    }
+    if (!["string", "number", "boolean"].includes(typeof rawValue)) {
+      throw new Error("GitHub output " + key + " must be scalar.")
+    }
+    const value = String(rawValue)
+    if (/[\u0000\r\n]/u.test(value)) {
+      throw new Error("GitHub output " + key + " contains a line break.")
+    }
+    result += key + "=" + value + "\n"
+  }
+  return result
+}
+
+const writeGitHubOutputs = (outputPath, outputs) => {
+  appendFileSync(outputPath, formatGitHubOutputs(outputs), "utf8")
+}
+
+const hash = (algorithm, contents, encoding) =>
+  createHash(algorithm).update(contents).digest(encoding)
+
+const assertRegularFile = (filePath, label) => {
+  const metadata = lstatSync(filePath)
+  if (metadata.isSymbolicLink() || !metadata.isFile()) {
+    throw new Error(label + " must be a regular file and not a symbolic link.")
+  }
+  return metadata
+}
+
+const assertDirectory = (directoryPath, label) => {
+  const metadata = lstatSync(directoryPath)
+  if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+    throw new Error(label + " must be a directory and not a symbolic link.")
+  }
+}
+
+const assertResourcePath = (resourcePath) => {
+  if (
+    typeof resourcePath !== "string" ||
+    resourcePath.length === 0 ||
+    resourcePath !== resourcePath.normalize("NFC") ||
+    path.posix.isAbsolute(resourcePath) ||
+    path.win32.isAbsolute(resourcePath) ||
+    resourcePath.includes("\\") ||
+    /[\u0000-\u001f\u007f-\u009f]/u.test(resourcePath)
+  ) {
+    throw new Error("Unsafe artifact resource path " + JSON.stringify(resourcePath) + ".")
+  }
+  const segments = resourcePath.split("/")
+  if (
+    segments.some((segment) => segment === "" || segment === "." || segment === "..") ||
+    path.posix.normalize(resourcePath) !== resourcePath ||
+    resourcePath === MANIFEST_FILE
+  ) {
+    throw new Error("Unsafe artifact resource path " + JSON.stringify(resourcePath) + ".")
+  }
+  return resourcePath
+}
+
+const listResourcePaths = (distDirectory) => {
+  assertDirectory(distDirectory, "Artifact dist root")
+  const resources = []
+  const visit = (directory, prefix) => {
+    const entries = readdirSync(directory, { withFileTypes: true }).sort((left, right) =>
+      left.name.localeCompare(right.name),
+    )
+    for (const entry of entries) {
+      const relativePath = prefix ? prefix + "/" + entry.name : entry.name
+      const absolutePath = path.join(directory, entry.name)
+      if (relativePath === MANIFEST_FILE) continue
+      assertResourcePath(relativePath)
+      if (entry.isSymbolicLink()) {
+        throw new Error("Artifact resource " + relativePath + " must not be a symlink.")
+      }
+      if (entry.isDirectory()) {
+        visit(absolutePath, relativePath)
+      } else if (entry.isFile()) {
+        resources.push(relativePath)
+      } else {
+        throw new Error("Artifact resource " + relativePath + " is not a regular file.")
+      }
+    }
+  }
+  visit(distDirectory, "")
+  return resources.sort()
+}
+
+const resourceRecord = (distDirectory, resourcePath) => {
+  assertResourcePath(resourcePath)
+  const absolutePath = path.join(distDirectory, ...resourcePath.split("/"))
+  const metadata = assertRegularFile(
+    absolutePath,
+    "Artifact resource " + resourcePath,
+  )
+  const contents = readFileSync(absolutePath)
+  if (metadata.size !== contents.byteLength) {
+    throw new Error("Artifact resource " + resourcePath + " changed while read.")
+  }
+  return {
+    path: resourcePath,
+    size: contents.byteLength,
+    sha256: hash("sha256", contents, "hex"),
+  }
+}
+
+const calculateResourcesSha256 = (resources) =>
+  hash(
+    "sha256",
+    resources
+      .map(
+        (resource) =>
+          resource.path +
+          "\0" +
+          resource.size +
+          "\0" +
+          resource.sha256 +
+          "\n",
+      )
+      .join(""),
+    "hex",
+  )
+
+const verifyTarball = (config, packageName, tarballPath) => {
+  validateConfig(config)
+  const selected = selectFrontend(config, packageName)
+  const absolutePath = path.resolve(tarballPath)
+  assertRegularFile(absolutePath, "Downloaded npm tarball")
+  const contents = readFileSync(absolutePath)
+  const actualShasum = hash("sha1", contents, "hex")
+  const actualIntegrity = "sha512-" + hash("sha512", contents, "base64")
+  if (actualShasum !== selected.identity.npmShasum) {
+    throw new Error(
+      "Downloaded npm tarball SHA-1 " +
+        actualShasum +
+        " does not match the committed identity.",
+    )
+  }
+  if (actualIntegrity !== selected.identity.npmIntegrity) {
+    throw new Error(
+      "Downloaded npm tarball integrity does not match the committed identity.",
+    )
+  }
+  return {
+    packageName: selected.identity.packageName,
+    packageVersion: selected.identity.packageVersion,
+    npmShasum: actualShasum,
+    npmIntegrity: actualIntegrity,
+  }
+}
+
+const readCanonicalManifest = (manifestPath) => {
+  assertRegularFile(manifestPath, "Universal artifact manifest")
+  const source = readFileSync(manifestPath, "utf8")
+  let manifest
+  try {
+    manifest = JSON.parse(source)
+  } catch (error) {
+    throw new Error(
+      "Universal artifact manifest is not valid JSON: " +
+        (error instanceof Error ? error.message : String(error)),
+    )
+  }
+  if (source !== JSON.stringify(manifest, null, 2) + "\n") {
+    throw new Error("Universal artifact manifest is not canonical JSON.")
+  }
+  return { manifest, source }
+}
+
+const verifyLotusNextManifest = (packageDirectory, expected) => {
+  const distDirectory = path.join(packageDirectory, "dist")
+  assertDirectory(distDirectory, "Lotus Next dist root")
+  const manifestPath = path.join(distDirectory, MANIFEST_FILE)
+  const { manifest, source } = readCanonicalManifest(manifestPath)
+  const actualManifestSha256 = hash("sha256", source, "hex")
+  if (actualManifestSha256 !== expected.manifestSha256) {
+    throw new Error(
+      "Universal artifact manifest SHA-256 does not match the committed identity.",
+    )
+  }
+  assertExactKeys(
+    manifest,
+    [
+      "schemaVersion",
+      "packageName",
+      "packageVersion",
+      "sourceRevision",
+      "sourceDirty",
+      "entrypoint",
+      "resourcesSha256",
+      "resources",
+    ],
+    "Universal artifact manifest",
+  )
+  const expectedIdentity = {
+    schemaVersion: expected.manifestSchemaVersion,
+    packageName: expected.packageName,
+    packageVersion: expected.packageVersion,
+    sourceRevision: expected.sourceRevision,
+    sourceDirty: expected.sourceDirty,
+    entrypoint: expected.entrypoint,
+    resourcesSha256: expected.resourcesSha256,
+  }
+  for (const [key, expectedValue] of Object.entries(expectedIdentity)) {
+    if (manifest[key] !== expectedValue) {
+      throw new Error(
+        "Universal artifact manifest " +
+          key +
+          " does not match the committed identity.",
+      )
+    }
+  }
+  if (!Array.isArray(manifest.resources) || manifest.resources.length === 0) {
+    throw new Error("Universal artifact manifest resources must be non-empty.")
+  }
+  let previousPath
+  for (const [index, resource] of manifest.resources.entries()) {
+    assertExactKeys(
+      resource,
+      ["path", "size", "sha256"],
+      "Universal artifact resource " + index,
+    )
+    assertResourcePath(resource.path)
+    if (previousPath !== undefined && resource.path <= previousPath) {
+      throw new Error("Universal artifact resources must be unique and sorted.")
+    }
+    if (!Number.isSafeInteger(resource.size) || resource.size < 0) {
+      throw new Error("Artifact resource " + resource.path + " has an invalid size.")
+    }
+    assertDigest(
+      resource.sha256,
+      sha256Pattern,
+      "Artifact resource " + resource.path + " SHA-256",
+    )
+    previousPath = resource.path
+  }
+  if (!manifest.resources.some((resource) => resource.path === manifest.entrypoint)) {
+    throw new Error("Universal artifact manifest does not contain its entrypoint.")
+  }
+  if (calculateResourcesSha256(manifest.resources) !== expected.resourcesSha256) {
+    throw new Error("Universal artifact combined resource digest is invalid.")
+  }
+
+  const actualPaths = listResourcePaths(distDirectory)
+  const declaredPaths = manifest.resources.map((resource) => resource.path)
+  if (
+    actualPaths.length !== declaredPaths.length ||
+    actualPaths.some((resourcePath, index) => resourcePath !== declaredPaths[index])
+  ) {
+    throw new Error("Universal artifact resource inventory does not match the package.")
+  }
+  for (const [index, resourcePath] of actualPaths.entries()) {
+    const actual = resourceRecord(distDirectory, resourcePath)
+    const declared = manifest.resources[index]
+    if (actual.size !== declared.size || actual.sha256 !== declared.sha256) {
+      throw new Error(
+        "Artifact resource " + resourcePath + " does not match its manifest.",
+      )
+    }
+  }
+  return {
+    manifestSha256: actualManifestSha256,
+    resourcesSha256: expected.resourcesSha256,
+    resourceCount: manifest.resources.length,
+  }
+}
+
+const verifyPackageArtifact = (config, packageName, packageDirectory) => {
+  validateConfig(config)
+  const selected = selectFrontend(config, packageName)
+  const absoluteDirectory = path.resolve(packageDirectory)
+  assertDirectory(absoluteDirectory, "Extracted npm package")
+  const packageJsonPath = path.join(absoluteDirectory, "package.json")
+  assertRegularFile(packageJsonPath, "Extracted package.json")
+  let packageJson
+  try {
+    packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"))
+  } catch (error) {
+    throw new Error(
+      "Extracted package.json is invalid: " +
+        (error instanceof Error ? error.message : String(error)),
+    )
+  }
+  if (
+    packageJson.name !== selected.identity.packageName ||
+    packageJson.version !== selected.identity.packageVersion
+  ) {
+    throw new Error("Extracted package identity does not match the committed selection.")
+  }
+
+  if (selected.selection === "lotus-next") {
+    return {
+      selection: selected.selection,
+      packageName: packageJson.name,
+      packageVersion: packageJson.version,
+      ...verifyLotusNextManifest(absoluteDirectory, selected.identity),
+    }
+  }
+
+  const legacyEntrypoint = path.join(absoluteDirectory, "dist", "index.html")
+  assertRegularFile(legacyEntrypoint, "Legacy rollback entrypoint")
+  return {
+    selection: selected.selection,
+    packageName: packageJson.name,
+    packageVersion: packageJson.version,
+  }
+}
+
+const parseArguments = (rawArguments) => {
+  const values = new Map()
+  if (rawArguments.length % 2 !== 0) {
+    throw new Error("Every command option must have a value.")
+  }
+  for (let index = 0; index < rawArguments.length; index += 2) {
+    const name = rawArguments[index]
+    const value = rawArguments[index + 1]
+    if (!name.startsWith("--") || values.has(name)) {
+      throw new Error("Invalid or duplicate command option " + JSON.stringify(name) + ".")
+    }
+    values.set(name, value)
+  }
+  return values
+}
+
+const requireOption = (arguments_, name) => {
+  if (!arguments_.has(name) || arguments_.get(name) === "") {
+    throw new Error("Missing required option " + name + ".")
+  }
+  return arguments_.get(name)
+}
+
+const rejectUnknownOptions = (arguments_, allowed) => {
+  for (const name of arguments_.keys()) {
+    if (!allowed.has(name)) {
+      throw new Error("Unsupported command option " + name + ".")
+    }
+  }
+}
+
+const runCli = () => {
+  const [command, ...rawArguments] = process.argv.slice(2)
+  const arguments_ = parseArguments(rawArguments)
+
+  if (command === "validate") {
+    rejectUnknownOptions(arguments_, new Set(["--config"]))
+    const config = readConfig(requireOption(arguments_, "--config"))
+    process.stdout.write(
+      "Validated release-train config schema " + config.schemaVersion + ".\n",
+    )
+    return
+  }
+
+  if (command === "resolve") {
+    rejectUnknownOptions(
+      arguments_,
+      new Set([
+        "--config",
+        "--targets",
+        "--frontend-package",
+        "--release-version",
+        "--bamboo-version",
+        "--bodhi-version",
+        "--resume",
+        "--github-output",
+      ]),
+    )
+    const config = readConfig(requireOption(arguments_, "--config"))
+    const outputs = resolvePolicy(config, {
+      targets: arguments_.get("--targets"),
+      frontendPackage: arguments_.get("--frontend-package"),
+      releaseVersion: arguments_.get("--release-version"),
+      bambooVersion: arguments_.get("--bamboo-version"),
+      bodhiVersion: arguments_.get("--bodhi-version"),
+      resume: arguments_.get("--resume"),
+    })
+    if (arguments_.has("--github-output")) {
+      writeGitHubOutputs(requireOption(arguments_, "--github-output"), outputs)
+    }
+    process.stdout.write(JSON.stringify(outputs, null, 2) + "\n")
+    return
+  }
+
+  if (command === "verify-tarball") {
+    rejectUnknownOptions(
+      arguments_,
+      new Set(["--config", "--frontend-package", "--tarball"]),
+    )
+    const config = readConfig(requireOption(arguments_, "--config"))
+    const result = verifyTarball(
+      config,
+      requireOption(arguments_, "--frontend-package"),
+      requireOption(arguments_, "--tarball"),
+    )
+    process.stdout.write(
+      "Verified npm tarball for " +
+        result.packageName +
+        "@" +
+        result.packageVersion +
+        " (" +
+        result.npmShasum +
+        ").\n",
+    )
+    return
+  }
+
+  if (command === "verify-package") {
+    rejectUnknownOptions(
+      arguments_,
+      new Set(["--config", "--frontend-package", "--package-dir"]),
+    )
+    const config = readConfig(requireOption(arguments_, "--config"))
+    const result = verifyPackageArtifact(
+      config,
+      requireOption(arguments_, "--frontend-package"),
+      requireOption(arguments_, "--package-dir"),
+    )
+    const resourceSummary =
+      result.resourceCount === undefined ? "" : ", " + result.resourceCount + " resources"
+    process.stdout.write(
+      "Verified extracted " +
+        result.packageName +
+        "@" +
+        result.packageVersion +
+        " (" +
+        result.selection +
+        resourceSummary +
+        ").\n",
+    )
+    return
+  }
+
+  throw new Error(
+    "Usage: release-train-policy.cjs validate|resolve|verify-tarball|verify-package [options]",
+  )
+}
+
+module.exports = {
+  CONFIG_SCHEMA_VERSION,
+  LEGACY_LOTUS_PACKAGE,
+  LOTUS_NEXT_PACKAGE,
+  calculateResourcesSha256,
+  formatGitHubOutputs,
+  listResourcePaths,
+  readConfig,
+  resourceRecord,
+  resolvePolicy,
+  selectFrontend,
+  validateConfig,
+  verifyPackageArtifact,
+  verifyTarball,
+}
+
+if (require.main === module) {
+  try {
+    runCli()
+  } catch (error) {
+    process.stderr.write(
+      (error instanceof Error ? error.message : String(error)) + "\n",
+    )
+    process.exitCode = 1
+  }
+}

--- a/scripts/release-train-policy.test.cjs
+++ b/scripts/release-train-policy.test.cjs
@@ -1,0 +1,282 @@
+"use strict"
+
+const assert = require("node:assert/strict")
+const { createHash } = require("node:crypto")
+const {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} = require("node:fs")
+const os = require("node:os")
+const path = require("node:path")
+const test = require("node:test")
+
+const {
+  calculateResourcesSha256,
+  formatGitHubOutputs,
+  readConfig,
+  resourceRecord,
+  resolvePolicy,
+  validateConfig,
+  verifyPackageArtifact,
+  verifyTarball,
+} = require("./release-train-policy.cjs")
+
+const repositoryRoot = path.resolve(__dirname, "..")
+const configPath = path.join(
+  repositoryRoot,
+  ".github",
+  "release-train.config.json",
+)
+const clone = (value) => JSON.parse(JSON.stringify(value))
+const digest = (algorithm, value, encoding) =>
+  createHash(algorithm).update(value).digest(encoding)
+
+test("accepts the committed release authority", () => {
+  const config = readConfig(configPath)
+  assert.equal(config.schemaVersion, 2)
+  assert.equal(config.sources.bamboo.ref, "dev")
+  assert.equal(
+    config.sources.bamboo.revision,
+    "a8b5385dc4318ab02ba35c0692bdf48914275f6c",
+  )
+  assert.equal(
+    config.sources.bodhi.revision,
+    "d6b3353577ece7587ca3c71aafada076032f2478",
+  )
+  assert.deepEqual(config.versions, {
+    release: "2026.9.14",
+    bamboo: "2026.9.12",
+    bodhi: "2026.9.12",
+  })
+  assert.equal(config.frontend.defaultPackage, "@bigduu/lotus-next")
+  assert.equal(config.frontend.lotusNext.packageVersion, "2026.9.14")
+  assert.equal(
+    config.frontend.lotusNext.sourceRevision,
+    "ae17b50574ccd86395cbc226b50c9fb2f0f51e0f",
+  )
+  assert.equal(config.frontend.lotusNext.sourceDirty, false)
+})
+
+test("defaults to a Bamboo then Bodhi train with the locked Lotus Next artifact", () => {
+  const config = readConfig(configPath)
+  const resolved = resolvePolicy(config)
+  assert.equal(resolved.include_bamboo, "true")
+  assert.equal(resolved.include_bodhi, "true")
+  assert.equal(resolved.release_version, "2026.9.14")
+  assert.equal(resolved.bamboo_version, "2026.9.14")
+  assert.equal(resolved.bodhi_version, "2026.9.14")
+  assert.equal(resolved.frontend_selection, "lotus-next")
+  assert.equal(resolved.frontend_package, "@bigduu/lotus-next")
+  assert.equal(resolved.frontend_version, "2026.9.14")
+})
+
+test("preserves partial-train version pinning", () => {
+  const config = readConfig(configPath)
+  const resolved = resolvePolicy(config, { targets: "bodhi" })
+  assert.equal(resolved.include_bamboo, "false")
+  assert.equal(resolved.include_bodhi, "true")
+  assert.equal(resolved.bamboo_version, "2026.9.12")
+  assert.equal(resolved.bodhi_version, "2026.9.14")
+})
+
+test("resolves only the fixed legacy rollback when explicitly selected", () => {
+  const config = readConfig(configPath)
+  const resolved = resolvePolicy(config, {
+    targets: "bamboo",
+    frontendPackage: "@bigduu/lotus",
+    releaseVersion: "2026.9.15",
+  })
+  assert.equal(resolved.frontend_selection, "legacy-rollback")
+  assert.equal(resolved.frontend_package, "@bigduu/lotus")
+  assert.equal(resolved.frontend_version, "2026.8.28")
+  assert.equal(resolved.bamboo_version, "2026.9.15")
+  assert.equal(resolved.bodhi_version, "2026.9.12")
+})
+
+test("rejects malformed or mismatched release authority", () => {
+  const config = readConfig(configPath)
+
+  const extraKey = clone(config)
+  extraKey.unreviewed = true
+  assert.throws(() => validateConfig(extraKey), /must contain exactly/)
+
+  const dirtySource = clone(config)
+  dirtySource.frontend.lotusNext.sourceDirty = true
+  assert.throws(() => validateConfig(dirtySource), /sourceDirty must be exactly false/)
+
+  const wrongDefault = clone(config)
+  wrongDefault.frontend.defaultPackage = "@bigduu/lotus"
+  assert.throws(() => validateConfig(wrongDefault), /defaultPackage/)
+
+  const badRevision = clone(config)
+  badRevision.sources.bamboo.revision = "main"
+  assert.throws(() => validateConfig(badRevision), /Git object ID/)
+
+  const badIntegrity = clone(config)
+  badIntegrity.frontend.legacyRollback.npmIntegrity = "sha512-not-base64"
+  assert.throws(() => validateConfig(badIntegrity), /canonical SHA-512/)
+})
+
+test("rejects moving versions, unknown targets, and uncommitted package choices", () => {
+  const config = readConfig(configPath)
+  assert.throws(
+    () => resolvePolicy(config, { releaseVersion: "latest" }),
+    /exact, non-placeholder SemVer/,
+  )
+  assert.throws(
+    () => resolvePolicy(config, { targets: "lotus" }),
+    /Unknown release target/,
+  )
+  assert.throws(
+    () => resolvePolicy(config, { targets: "bamboo,bamboo" }),
+    /must not contain duplicates/,
+  )
+  assert.throws(
+    () => resolvePolicy(config, { frontendPackage: "@bigduu/lotus-next@latest" }),
+    /frontend_package must be exactly/,
+  )
+})
+
+test("formats line-safe GitHub outputs and rejects output injection", () => {
+  assert.equal(
+    formatGitHubOutputs({ include_bamboo: "true", version: "2026.9.14" }),
+    "include_bamboo=true\nversion=2026.9.14\n",
+  )
+  assert.throws(
+    () => formatGitHubOutputs({ version: "2026.9.14\npoison=true" }),
+    /contains a line break/,
+  )
+  assert.throws(
+    () => formatGitHubOutputs({ "bad-key": "value" }),
+    /Unsafe GitHub output key/,
+  )
+})
+
+test("verifies the downloaded tarball against both locked npm digests", (t) => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "zenith-release-policy-"))
+  t.after(() => rmSync(directory, { recursive: true, force: true }))
+  const tarball = path.join(directory, "artifact.tgz")
+  const contents = Buffer.from("locked registry artifact")
+  writeFileSync(tarball, contents)
+
+  const config = clone(readConfig(configPath))
+  config.frontend.legacyRollback.npmShasum = digest("sha1", contents, "hex")
+  config.frontend.legacyRollback.npmIntegrity =
+    "sha512-" + digest("sha512", contents, "base64")
+  validateConfig(config)
+
+  const verified = verifyTarball(config, "@bigduu/lotus", tarball)
+  assert.equal(verified.npmShasum, config.frontend.legacyRollback.npmShasum)
+
+  writeFileSync(tarball, Buffer.from("mutated registry artifact"))
+  assert.throws(
+    () => verifyTarball(config, "@bigduu/lotus", tarball),
+    /does not match the committed identity/,
+  )
+})
+
+test("verifies every Lotus Next manifest resource and rejects byte drift", (t) => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "zenith-release-policy-"))
+  t.after(() => rmSync(directory, { recursive: true, force: true }))
+  const packageDirectory = path.join(directory, "package")
+  const distDirectory = path.join(packageDirectory, "dist")
+  mkdirSync(path.join(distDirectory, "assets"), { recursive: true })
+  writeFileSync(
+    path.join(packageDirectory, "package.json"),
+    JSON.stringify(
+      { name: "@bigduu/lotus-next", version: "2026.9.14" },
+      null,
+      2,
+    ) + "\n",
+  )
+  writeFileSync(path.join(distDirectory, "index.html"), "<main>Lotus Next</main>\n")
+  writeFileSync(path.join(distDirectory, "assets", "app.js"), "export {}\n")
+
+  const resources = ["assets/app.js", "index.html"].map((resourcePath) =>
+    resourceRecord(distDirectory, resourcePath),
+  )
+  const resourcesSha256 = calculateResourcesSha256(resources)
+  const config = clone(readConfig(configPath))
+  config.frontend.lotusNext.resourcesSha256 = resourcesSha256
+  const manifest = {
+    schemaVersion: 1,
+    packageName: config.frontend.lotusNext.packageName,
+    packageVersion: config.frontend.lotusNext.packageVersion,
+    sourceRevision: config.frontend.lotusNext.sourceRevision,
+    sourceDirty: false,
+    entrypoint: "index.html",
+    resourcesSha256,
+    resources,
+  }
+  const manifestSource = JSON.stringify(manifest, null, 2) + "\n"
+  writeFileSync(path.join(distDirectory, "lotus-next-manifest.json"), manifestSource)
+  config.frontend.lotusNext.manifestSha256 = digest(
+    "sha256",
+    manifestSource,
+    "hex",
+  )
+  validateConfig(config)
+
+  const verified = verifyPackageArtifact(
+    config,
+    "@bigduu/lotus-next",
+    packageDirectory,
+  )
+  assert.equal(verified.resourceCount, 2)
+  assert.equal(verified.resourcesSha256, resourcesSha256)
+
+  writeFileSync(path.join(distDirectory, "index.html"), "<main>tampered</main>\n")
+  assert.throws(
+    () =>
+      verifyPackageArtifact(config, "@bigduu/lotus-next", packageDirectory),
+    /does not match its manifest/,
+  )
+})
+
+test("wires the release and nightly workflows to the immutable frontend", () => {
+  const releaseWorkflow = readFileSync(
+    path.join(repositoryRoot, ".github", "workflows", "release-train.yml"),
+    "utf8",
+  )
+  const nightlyWorkflow = readFileSync(
+    path.join(repositoryRoot, ".github", "workflows", "nightly-release.yml"),
+    "utf8",
+  )
+  const policyWorkflow = readFileSync(
+    path.join(repositoryRoot, ".github", "workflows", "release-policy.yml"),
+    "utf8",
+  )
+
+  assert.match(releaseWorkflow, /default: "bamboo,bodhi"/)
+  assert.match(releaseWorkflow, /release-train-policy\.cjs" verify-tarball/)
+  assert.match(releaseWorkflow, /release-train-policy\.cjs" verify-package/)
+  assert.match(releaseWorkflow, /frontend_package=\$\{FRONTEND_PACKAGE\}/)
+  assert.match(releaseWorkflow, /lotus_version=\$\{FRONTEND_VERSION\}/)
+  assert.match(releaseWorkflow, /bamboo_ref=\$\{BAMBOO_REVISION\}/)
+  assert.doesNotMatch(releaseWorkflow, /include_lotus|INCLUDE_LOTUS/)
+  assert.doesNotMatch(releaseWorkflow, /lotus_skip_tests/i)
+  assert.doesNotMatch(releaseWorkflow, /bigduu\/Lotus/)
+  assert.doesNotMatch(releaseWorkflow, /publish-npm\.yml/)
+
+  assert.match(nightlyWorkflow, /registry\.npmjs\.org\/@bigduu%2flotus-next/)
+  assert.match(nightlyWorkflow, /\.versions\.bamboo = \$v/)
+  assert.match(nightlyWorkflow, /\.versions\.bodhi = \$v/)
+  assert.match(nightlyWorkflow, /-f targets=bamboo,bodhi/)
+  assert.doesNotMatch(nightlyWorkflow, /\.versions\.lotus\s*=/)
+  assert.doesNotMatch(
+    nightlyWorkflow,
+    /registry\.npmjs\.org\/@bigduu%2flotus"/,
+  )
+  assert.doesNotMatch(nightlyWorkflow, /lotus_skip_tests/i)
+
+  assert.match(policyWorkflow, /name: Validate Release Policy/)
+  assert.match(policyWorkflow, /node --test scripts\/release-train-policy\.test\.cjs/)
+  assert.match(policyWorkflow, /Round-trip both committed npm artifacts/)
+  assert.match(
+    policyWorkflow,
+    /8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8/,
+  )
+})

--- a/scripts/release-train-policy.test.cjs
+++ b/scripts/release-train-policy.test.cjs
@@ -265,6 +265,7 @@ test("wires the release and nightly workflows to the immutable frontend", () => 
   assert.match(nightlyWorkflow, /\.versions\.bamboo = \$v/)
   assert.match(nightlyWorkflow, /\.versions\.bodhi = \$v/)
   assert.match(nightlyWorkflow, /-f targets=bamboo,bodhi/)
+  assert.match(nightlyWorkflow, /-f release_version="\$\{new_version\}"/)
   assert.doesNotMatch(nightlyWorkflow, /\.versions\.lotus\s*=/)
   assert.doesNotMatch(
     nightlyWorkflow,


### PR DESCRIPTION
## Summary

- replace the legacy Lotus → Bamboo → Bodhi producer chain with a downstream-only Bamboo → Bodhi train that consumes one committed, immutable frontend artifact
- make `.github/release-train.config.json` the strict authority for accepted Bamboo/Bodhi refs and revisions, exact Lotus Next source/manifest/npm identity, downstream versions, and the sole fixed legacy rollback
- add a Node policy/verifier with focused tests plus a path-scoped GitHub check that re-downloads and verifies both npm artifacts
- update nightly versioning to scan Lotus Next while changing only Bamboo/Bodhi versions, and align the release/migration documentation

## Fail-closed behavior

- default selection is exactly `@bigduu/lotus-next@2026.9.14`; no moving `latest`, skip-tests input, frontend producer leg, or automatic Lotus Next publication remains
- before cross-repository dispatch, validate canonical config, exact root gitlinks, live accepted Bamboo/Bodhi refs, selected tarball SHA-1/integrity, and the full Lotus Next universal manifest/resource inventory
- Bamboo receives the selected package/version; Bodhi receives the same identity plus accepted Bamboo revision `a8b5385dc4318ab02ba35c0692bdf48914275f6c`
- retain downstream collision detection, partial targets, crates.io propagation waiting, and exact-version resume behavior

## Test Plan

- `node --test scripts/release-train-policy.test.cjs` — 10/10 pass locally
- same suite on Node 22 and Node 24 — 10/10 pass on each
- `actionlint .github/workflows/release-policy.yml .github/workflows/release-train.yml .github/workflows/nightly-release.yml .github/workflows/submodule-guard.yml` — pass
- fresh public-registry round trips verified `@bigduu/lotus-next@2026.9.14` (34 manifest resources) and fixed `@bigduu/lotus@2026.8.28` against independently computed tarball digests
- verified root pointers and live accepted refs for Bamboo `a8b5385d…`, Bodhi `d6b33535…`, and Lotus Next artifact source `ae17b505…`
- verified `bamboo-agent@2026.9.14` and Bodhi `app-v2026.9.14` are vacant; no release workflow was dispatched
- GitHub Release Policy and root guard checks will rerun on the exact PR head

## Non-goals

- no npm, crate, image, or desktop publication
- no submodule source or pointer change
- no local/remote responsiveness, two-launch Jiandu, rollback removal, legacy reconciliation, or archive acceptance

Closes #231